### PR TITLE
[Cleanup & Fix] Find and Replace dialog updates.

### DIFF
--- a/src/dialogs/story-search/index.js
+++ b/src/dialogs/story-search/index.js
@@ -32,12 +32,18 @@ module.exports = Vue.extend({
 			let source = this.search;
 
 			/*
-			Escape regular expression characters in what the user typed unless
-			they indicated that they're using a regexp.
+			Escape regular expression meta characters in what the user typed
+			unless they indicated that they're using a regexp.
+
+			The only meta characters which need to be escaped are the escape
+			character (backslash) itself and the syntax characters.
+
+			* [21.2.1 Patterns](http://ecma-international.org/ecma-262/8.0/#sec-patterns)
+			* [SyntaxCharacter](http://ecma-international.org/ecma-262/8.0/#prod-SyntaxCharacter)
 			*/
 
 			if (!this.regexp) {
-				source = source.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+				source = source.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
 			}
 
 			return new RegExp('(' + source + ')', flags);

--- a/src/dialogs/story-search/result.js
+++ b/src/dialogs/story-search/result.js
@@ -50,12 +50,12 @@ module.exports = Vue.extend({
 			const name = this.searchNames ?
 				this.match.passage.name.replace(
 					this.searchRegexp,
-					this.replaceWith
+					() => this.replaceWith
 				)
 				: undefined;
 			const text = this.match.passage.text.replace(
 				this.searchRegexp,
-				this.replaceWith
+				() => this.replaceWith
 			);
 
 			this.updatePassage(


### PR DESCRIPTION
### [Cleanup] Reduced the set of RegExp meta characters replaced in search strings to only what's required.

The current set of escaped characters is unnecessarily broad.  It even includes characters which are not RegExp meta characters at all, syntax or otherwise.

### [Fix] Disable special replacement patterns within replacement strings.

This should be self explanatory.  The special replacement patterns are likely to cause more surprise and grief for the average user than they are to be useful, so disabling them is best.

**PS:** Allowing the special replacement patterns when the user elects to use regular expressions directly might not be a terrible idea.  I can make that change if you like.