### PR TITLE
Request admin so shortcuts get put in All Users

### DIFF
--- a/scripts/nsis-script.ejs
+++ b/scripts/nsis-script.ejs
@@ -11,7 +11,7 @@ OutFile "dist\uploads\twine_<%- version %>_<%- arch %>.exe"
 ; AutoCloseWindow false ; (can be true for the window go away automatically at end)
 ; ShowInstDetails hide ; (can be show to have them shown, or nevershow to disable)
 ; SetDateSave off ; (can be on to have files restored to their orginal date)
-RequestExecutionLevel highest
+RequestExecutionLevel admin
 
 InstallDir "$PROGRAMFILES\<%- name %> 2"
 InstallDirRegKey HKEY_LOCAL_MACHINE "SOFTWARE\<%- regKey %>" ""


### PR DESCRIPTION
Using highest will make the $MSPROGRAMS variable point to the current user's profile for the start menu shortcuts instead of putting them in the All Users start menu.  This makes it harder for other computer users to get to Twine and for admins doing silent installs.  Further info here: http://nsis.sourceforge.net/Reference/RequestExecutionLevel