### PR TITLE
fixed faulty check for selected passages

### DIFF
--- a/src/story-edit-view/index.js
+++ b/src/story-edit-view/index.js
@@ -465,10 +465,9 @@ module.exports = Vue.extend({
 				this.story.id,
 				passage.id,
 				this.gridSize,
-				options.ignoreSelected && (passage =>
-					!this.selectedChildren.some(view =>
-						view.passage.id === passage
-					))
+				options.ignoreSelected && (other =>
+					!other.selected
+				)
 			);
 		}
 	},


### PR DESCRIPTION
This commit fixes an anonymous inner function that was supposed to be filtering out selected passages. The functionality of the filter should have been:

If the  "other" passage is selected, then the filter returns false and collision with the passage is disabled. Otherwise the filter returns true and collision can occur.