### PR TITLE
Issue 420 snapping to grid issues

### DIFF
--- a/src/common/rect.js
+++ b/src/common/rect.js
@@ -128,7 +128,8 @@ module.exports = {
 		// Decide whether moving left or right would resolve the overlap with
 		// the least motion.
 
-		let xChange, yChange;
+		let xChange = 0;
+		let yChange = 0;
 
 		if (xOverlap !== 0) {
 			const leftMove = (mLeft - sLeft) + movable.width + spacing;

--- a/src/data/actions/passage.js
+++ b/src/data/actions/passage.js
@@ -67,14 +67,24 @@ const actions = module.exports = {
 			);
 		}
 
-		/* Displace by other passages. */
-
 		let passageRect = {
 			top: passage.top,
 			left: passage.left,
 			width: passage.width,
 			height: passage.height
 		};
+
+		/*
+		Displacement in snapToGrid mode is set to 0 to prevent spaces
+		being inserted between passages in a grid. Otherwise, overlapping
+		passages are separated out with 10 pixels between them.
+		*/
+
+		const displacementDistance = (story.snapToGrid && gridSize) ?
+			0
+			: 10;
+
+		/* Displace by other passages. */
 
 		story.passages.forEach(other => {
 			if (other === passage || (filter && !filter(other))) {
@@ -89,7 +99,7 @@ const actions = module.exports = {
 			};
 
 			if (rect.intersects(otherRect, passageRect)) {
-				rect.displace(passageRect, otherRect, 10);
+				rect.displace(passageRect, otherRect, displacementDistance);
 			}
 		});
 

--- a/src/data/actions/passage.spec.js
+++ b/src/data/actions/passage.spec.js
@@ -201,4 +201,89 @@ describe('passage actions module', () => {
 		expect(secondCall.args[2]).to.equal(fakeId + '2');
 		expect(secondCall.args[3].text).to.equal('[[$]]');
 	});
+
+	describe('snap to grid passage positioning', () => {	
+		it('snap overlapping passages to adjacent positions, when positioning passages()', () => {
+			let storyStore = {
+				dispatch: spy(),
+				state: {
+					story: {
+						stories: [
+							{
+								id: fakeId,
+								snapToGrid: true,
+								passages: [
+									{
+										id: fakeId,
+										name: 'Test',
+										text: 'a',
+										left: 10,
+										top: 10,
+										width: 10,
+										height: 10,
+										selected: true
+									},
+									{
+										id: fakeId + '2',
+										name: 'Test',
+										text: 'a',
+										left: 10,
+										top: 10,
+										width: 10,
+										height: 10,
+										selected: false
+									}
+								]
+							}
+						]
+					}
+				}
+			};
+	
+			/* Test overlapping from slightly below */
+			storyStore.state.story.stories[0].passages[0].top = 11;
+	
+			actions.positionPassage(storyStore, fakeId, fakeId, 10);
+
+			const firstCall = storyStore.dispatch.getCall(0);
+
+			expect(firstCall.args[3]).to.exist;
+			expect(firstCall.args[3].top).to.equal(20);
+			expect(firstCall.args[3].left).to.equal(10);
+	
+			/* Test overlapping from slightly above */
+			storyStore.state.story.stories[0].passages[0].top = 9;
+	
+			actions.positionPassage(storyStore, fakeId, fakeId, 10);
+
+			const secondCall = storyStore.dispatch.getCall(1);
+
+			expect(secondCall.args[3]).to.exist;
+			expect(secondCall.args[3].top).to.equal(0);
+			expect(secondCall.args[3].left).to.equal(10);
+	
+			/* Test overlapping from slightly leftwards */
+			storyStore.state.story.stories[0].passages[0].top = 10;
+			storyStore.state.story.stories[0].passages[0].left = 0;
+	
+			actions.positionPassage(storyStore, fakeId, fakeId, 10);
+
+			const thirdCall = storyStore.dispatch.getCall(2);
+
+			expect(thirdCall.args[3]).to.exist;
+			expect(thirdCall.args[3].top).to.equal(10);
+			expect(thirdCall.args[3].left).to.equal(0);
+	
+			/* Test overlapping from slightly rightwards */
+			storyStore.state.story.stories[0].passages[0].left = 11;
+	
+			actions.positionPassage(storyStore, fakeId, fakeId, 10);
+
+			const fourthCall = storyStore.dispatch.getCall(3);
+
+			expect(fourthCall.args[3]).to.exist;
+			expect(fourthCall.args[3].top).to.equal(10);
+			expect(fourthCall.args[3].left).to.equal(20);
+		});
+	});
 });

--- a/src/story-edit-view/index.js
+++ b/src/story-edit-view/index.js
@@ -126,7 +126,7 @@ module.exports = Vue.extend({
 		*/
 
 		selectedChildren() {
-			return this.$refs.passages.filter(p => p.selected);
+			return this.$refs.passages.filter(p => p.passage.selected);
 		},
 
 		/*
@@ -465,10 +465,8 @@ module.exports = Vue.extend({
 				this.story.id,
 				passage.id,
 				this.gridSize,
-				options.ignoreSelected && (passage =>
-					!this.selectedChildren.some(view =>
-						view.passage.id === passage
-					))
+				options.ignoreSelected && (otherPassage =>
+					!otherPassage.selected)
 			);
 		}
 	},

--- a/src/story-edit-view/index.js
+++ b/src/story-edit-view/index.js
@@ -425,10 +425,12 @@ module.exports = Vue.extend({
 
 		'passage-drag'(xOffset, yOffset) {
 			if (this.story.snapToGrid) {
-				this.screenDragOffsetX = Math.round(xOffset / this.gridSize) *
-					this.gridSize;
-				this.screenDragOffsetY = Math.round(yOffset / this.gridSize) *
-					this.gridSize;
+				const zoomedGridSize = this.gridSize * this.story.zoom;
+
+				this.screenDragOffsetX = Math.round(xOffset / zoomedGridSize) *
+					zoomedGridSize;
+				this.screenDragOffsetY = Math.round(yOffset / zoomedGridSize) *
+					zoomedGridSize;
 			}
 			else {
 				this.screenDragOffsetX = xOffset;
@@ -447,8 +449,10 @@ module.exports = Vue.extend({
 			this.screenDragOffsetY = 0;
 
 			if (this.story.snapToGrid) {
-				xOffset = Math.round(xOffset / this.gridSize) * this.gridSize;
-				yOffset = Math.round(yOffset / this.gridSize) * this.gridSize;
+				const zoomedGridSize = this.gridSize * this.story.zoom;
+
+				xOffset = Math.round(xOffset / zoomedGridSize) * zoomedGridSize;
+				yOffset = Math.round(yOffset / zoomedGridSize) * zoomedGridSize;
 			}
 
 			this.$broadcast('passage-drag-complete', xOffset, yOffset);


### PR DESCRIPTION
Fixes #420 - implements a series of logic updates that make the snap to grid mode work a little smoother and more predictably.

- When a dragged passage overlaps an existing passage, it will now snap to be adjacent to the existing passage no matter what direction it overlaps in (previously the behaviour was different between up/left and down/right)
- When dragging multiple selected passages, they now move together properly and don't intersect with one another
- Passages now match the background gridlines while being dragged at any zoom level