### PR TITLE
Easy support for upload or paste of images into stories as data URIs

### DIFF
--- a/developer_docs/README.md
+++ b/developer_docs/README.md
@@ -26,6 +26,7 @@ To enable development, you will need to clone the TwineJS Git repository,
 and [install Node](https://nodejs.org/).
 Instructions for getting started are contained in [the main README](../README.md),
 but the key commands are `npm install` followed by `npm start`.
+These commands and many others are defined in `package.json`.
 
 Files that end in `.spec.js` are unit tests, not part of the application logic proper.
 They can be useful for demonstrating how components are used, however.

--- a/developer_docs/README.md
+++ b/developer_docs/README.md
@@ -1,0 +1,140 @@
+# Developer documentation for TwineJS
+
+This documentation is intended to give an overview of the TwineJS code to new developers, who would like to start contributing.
+
+## Relationship among Twine components
+
+This project (`twinejs`) provides:
+
+- basic data types, chiefly `stories` made up of `passages`
+- a user interface for editing, importing, and exporting stories
+
+However, it does NOT dictate any real constraints on the content of passages.
+The content of passages is interpretted by `story formats` such as
+**Harlowe**, **SugarCube**, and **Snowman**.
+Those story formats provide the "runtime" for stories,
+and translate passage content into HTML, CSS, and JavaScript that a reader can interact with.
+
+## Basic tooling
+
+TwineJS is authored in JavaScript, using [the Vue framework](https://vuejs.org/).
+Vue is well-regarded for its simplicity and [excellent documentation for beginners](https://vuejs.org/v2/guide/).
+
+To enable development, you will need to clone the TwineJS Git repository,
+and [install Node](https://nodejs.org/).
+Instructions for getting started are contained in [the main README](../README.md),
+but the key commands are `npm install` followed by `npm start`.
+
+Files that end in `.spec.js` are unit tests, not part of the application logic proper.
+They can be useful for demonstrating how components are used, however.
+
+## Entry point
+
+The entry point appears to be `src/index.ejs`.
+Despite the extension, it appears to be an HTML file that includes all the external dependencies.
+It also creates the `#main` div which holds all the other app components.
+
+Twine itself appears to start in `src/index.js`.
+This initializes localization, and loads some key modules:
+
+- `store` (`src/data/store/`), which is a global singleton for shared state across Vue components.
+- `TwineRouter` (`src/common/router.js`), which maps URLs to the components displayed on each "page" of the application.
+
+## Shared state
+
+Many of these are exposed through the `store`, which is effectively a global variable:
+
+- `prefs` (`src/data/store/prefs.js`), for keeping global user preferences like default UI theme and default story format.
+- `story` (`src/data/store/story.js`), which holds all the user's stories, and provides methods to create/read/update/delete stories and passages.
+- `storyFormat` (`src/data/store/story-format.js`), which holds all of the available story formats.
+- `src/data/local-storage/`, which has code for saving stories and passages to the browser's `localStorage` object.
+
+## Core data structures
+
+These are easiest to understand by using your browser's developer tools to inspect `localStorage` for your Twine stories.
+All (?) Twine objects have a UUID to conveniently identify them.
+Since UUIDs are randomly generated, the actual UUIDs in your browser will differ from those shown here.
+
+### Stories
+
+`twine-stories` contains a comma-separated list of UUIDs of stories.
+
+`twine-stories-UUID` is an object like this:
+
+```
+id: "2236bf97-2ce3-446e-b59d-57d82e8ee714"
+ifid: "FF075B98-1476-4C21-816A-A4D3D166764E"
+lastUpdate: "2018-06-02T18:55:44.574Z"
+name: "Troll Battle"
+script: ""
+snapToGrid: false
+startPassage: "da03b0f9-2c2e-401d-be7f-e089dd099469"
+storyFormat: "Harlowe"
+storyFormatVersion: "2.1.0"
+stylesheet: ""
+tagColors: {}
+zoom: 1
+```
+
+### Passages
+
+`twine-passages` contains a comma-separated list of UUIDs of passages.
+
+`twine-passages-UUID` is an object like this:
+
+```
+height: 100
+id: "da03b0f9-2c2e-401d-be7f-e089dd099469"
+left: 488.5
+name: "Home"
+selected: true
+story: "2236bf97-2ce3-446e-b59d-57d82e8ee714"
+tags: []
+text: "The morning dawned clear and cold..."
+top: 251.5
+width: 100
+```
+
+### Story Formats
+
+`twine-story-formats` contains a comma-separated list of UUIDs of story formats.
+
+`twine-story-formats-UUID` is an object like this:
+
+```
+id: "396819a8-75fc-40e4-99a3-ad6bf98d0b03"
+loaded: false
+name: "Harlowe"
+url: "story-formats/harlowe-2.1.0/format.js"
+userAdded: false
+version: "2.1.0"
+```
+
+### Prefs
+
+`twine-prefs` contains a comma-separated list of UUIDs of preference objects.
+
+`twine-prefs-UUID` is an object like this:
+
+```
+id: "28d7fe60-52d2-4d69-8fe5-48180d43f7a8"
+name: "appTheme"
+value: "light"
+```
+
+## Parts of the UI
+
+You can generally trace from `src/common/router.js` to find the different pages of the app:
+
+- `src/story-list-view/`: the main page, showing all the available stories, allowing story import/export, and setting global prefs.
+- `src/story-edit-view/`:  the overview of a single story, showing passages as boxes connected by arrows.
+- `src/welcome/`: the introductory tutorial shown to new users on their first visit.
+- `src/locale/`:  allows the user to set their language (English, French, Spanish, etc).
+
+Some components used by these pages are in their own directories:
+
+- `src/editors/` contains the main text-editing dialogs for passages, extra JavaScript, and extra CSS.
+- `src/dialogs/` contains other pop-up dialogs, like the About box and story import.
+- `src/ui/` contains things like menus, buttons, and modal dialogs, which are base classes for other UI elements.
+
+## How To ...

--- a/developer_docs/README.md
+++ b/developer_docs/README.md
@@ -18,7 +18,9 @@ and translate passage content into HTML, CSS, and JavaScript that a reader can i
 ## Basic tooling
 
 TwineJS is authored in JavaScript, using [the Vue framework](https://vuejs.org/).
-Vue is well-regarded for its simplicity and [excellent documentation for beginners](https://vuejs.org/v2/guide/).
+Note that Twine uses Vue 1.x, although a 2.x series now exists.
+Vue is well-regarded for its simplicity and [excellent documentation for beginners](https://v1.vuejs.org/guide/).
+Be sure to use the older 1.0 documentation rather than the current 2.x docs.
 
 To enable development, you will need to clone the TwineJS Git repository,
 and [install Node](https://nodejs.org/).

--- a/developer_docs/README.md
+++ b/developer_docs/README.md
@@ -136,5 +136,3 @@ Some components used by these pages are in their own directories:
 - `src/editors/` contains the main text-editing dialogs for passages, extra JavaScript, and extra CSS.
 - `src/dialogs/` contains other pop-up dialogs, like the About box and story import.
 - `src/ui/` contains things like menus, buttons, and modal dialogs, which are base classes for other UI elements.
-
-## How To ...

--- a/src/dialogs/image-import/index.html
+++ b/src/dialogs/image-import/index.html
@@ -10,15 +10,15 @@
 			<input type="file" v-el:import-file @change="import($els.importFile.files[0])">
 		</p>
 
+		<p>
+			{{ 'Be aware that embedding large image can quickly use up all your storage space.' | say }}
+		</p>
+
 		<div class="buttons" v-if="!working">
 			<button class="subtle" @click="close">
 				<i class="fa fa-times"></i> {{ 'Cancel' | say }}
 			</button>
 		</div>
-
-		<p>
-			{{ 'Be aware that embedding large image can quickly use up all your storage space.' | say }}
-		</p>
 	</template>
 
 	<template v-if="status === 'working'">

--- a/src/dialogs/image-import/index.html
+++ b/src/dialogs/image-import/index.html
@@ -15,6 +15,10 @@
 				<i class="fa fa-times"></i> {{ 'Cancel' | say }}
 			</button>
 		</div>
+
+		<p>
+			{{ 'Be aware that embedding large image can quickly use up all your storage space.' | say }}
+		</p>
 	</template>
 
 	<template v-if="status === 'working'">

--- a/src/dialogs/image-import/index.html
+++ b/src/dialogs/image-import/index.html
@@ -1,0 +1,26 @@
+<modal-dialog v-ref:modal :origin="origin">
+	<span slot="title">{{ 'Import Image From File' | say }}</span>
+
+	<template v-if="status === 'waiting'">
+		<p>
+			<label for="importUpload">
+				{{ 'Import this image file:' | say }}
+			</label>
+
+			<input type="file" v-el:import-file @change="import($els.importFile.files[0])">
+		</p>
+
+		<div class="buttons" v-if="!working">
+			<button class="subtle" @click="close">
+				<i class="fa fa-times"></i> {{ 'Cancel' | say }}
+			</button>
+		</div>
+	</template>
+
+	<template v-if="status === 'working'">
+		<p>
+			<i class="fa fa-circle-o-notch fa-spin"></i>
+			{{ 'Working...' | say }}
+		</p>
+	</template>
+</modal-dialog>

--- a/src/dialogs/image-import/index.js
+++ b/src/dialogs/image-import/index.js
@@ -1,0 +1,72 @@
+/*
+A dialog which allows a user to import an image from a file. This returns a
+promise resolving to the image that was imported, as a data URI.
+*/
+
+const Vue = require('vue');
+const locale = require('../../locale');
+const { thenable } = require('../../vue/mixins/thenable');
+
+module.exports = Vue.extend({
+	template: require('./index.html'),
+
+	data: () => ({
+		/* A file to immediately import when mounted. */
+		immediateImport: null,
+
+		/*
+		Current state of the operation:
+		   * `waiting`: waiting for the user to select a file
+		   * `working`: working without user input
+		*/
+		status: 'waiting',
+	}),
+
+	ready() {
+		if (this.immediateImport) {
+			this.import(this.immediateImport);
+		}
+	},
+
+	methods: {
+		close() {
+			if (this.$refs.modal) {
+				this.$refs.modal.close();
+			}
+		},
+
+		import(file) {
+			this.status = 'working';
+
+			const reader = new FileReader();
+
+			// Copied from `file/load`.  Can't use that because it reads strings, not data URIs.
+			new Promise(resolve => {
+				reader.addEventListener('load', e => {
+					resolve(e.target.result);
+				});
+
+				reader.readAsDataURL(file);
+			})
+			.then(source => {
+				console.log("Imported "+source.length+" bytes, starting: "+source.substring(0, 40))
+				this.close();
+			});
+		}
+	},
+
+	components: {
+		'modal-dialog': require('../../ui/modal-dialog')
+	},
+
+	mixins: [thenable],
+
+	vuex: {
+		actions: {
+		},
+
+		getters: {
+			existingStories: state => state.story.stories
+		}
+	}
+});

--- a/src/dialogs/image-import/index.js
+++ b/src/dialogs/image-import/index.js
@@ -6,6 +6,7 @@ promise resolving to the image that was imported, as a data URI.
 const Vue = require('vue');
 const locale = require('../../locale');
 const { thenable } = require('../../vue/mixins/thenable');
+const { updatePassage } = require('../../data/actions/passage');
 
 module.exports = Vue.extend({
 	template: require('./index.html'),
@@ -20,6 +21,10 @@ module.exports = Vue.extend({
 		   * `working`: working without user input
 		*/
 		status: 'waiting',
+
+		// Where to insert the image
+		passageId: '',
+		storyId: '',
 	}),
 
 	ready() {
@@ -49,7 +54,14 @@ module.exports = Vue.extend({
 				reader.readAsDataURL(file);
 			})
 			.then(source => {
-				console.log("Imported "+source.length+" bytes, starting: "+source.substring(0, 40))
+				// It's not enough to directly modify the passage object -- changes won't persist.
+				// We have to call updatePassage() to make permanent changes.
+				this.updatePassage(
+					this.storyId,
+					this.passageId,
+					{ text: '<img src="'+source+'">', name: file.name }
+				);
+
 				this.close();
 			});
 		}
@@ -63,6 +75,7 @@ module.exports = Vue.extend({
 
 	vuex: {
 		actions: {
+			updatePassage
 		},
 
 		getters: {

--- a/src/dialogs/image-import/index.js
+++ b/src/dialogs/image-import/index.js
@@ -70,9 +70,7 @@ module.exports = Vue.extend({
 				this.updatePassage(
 					this.story.id,
 					newPassage.id,
-					// In a perfect world, we would query the story format for how to embed an image.
-					// In practice, all the standard formats seem to use the same HTML syntax for images.
-					{ text: '<img src="'+source+'">', name: file.name, tags: ['image'] }
+					{ text: source, name: file.name, tags: ['Twine.image'] }
 				);
 
 				this.close();

--- a/src/dialogs/image-import/index.js
+++ b/src/dialogs/image-import/index.js
@@ -59,7 +59,9 @@ module.exports = Vue.extend({
 				this.updatePassage(
 					this.storyId,
 					this.passageId,
-					{ text: '<img src="'+source+'">', name: file.name }
+					// In a perfect world, we would query the story format for how to embed an image.
+					// In practice, all the standard formats seem to use the same HTML syntax for images.
+					{ text: '<img src="'+source+'">', name: file.name, tags: ['image'] }
 				);
 
 				this.close();

--- a/src/dialogs/image-import/index.js
+++ b/src/dialogs/image-import/index.js
@@ -23,8 +23,10 @@ module.exports = Vue.extend({
 		status: 'waiting',
 
 		// Where to insert the image
-		passageId: '',
-		storyId: '',
+		story: '',
+
+		// The Vue component that can receive the passage-create event
+		dispatchTo: null,
 	}),
 
 	ready() {
@@ -54,11 +56,20 @@ module.exports = Vue.extend({
 				reader.readAsDataURL(file);
 			})
 			.then(source => {
+				// This does not return anything useful, but appears to execute synchronously.
+				// https://v1.vuejs.org/api/#vm-dispatch
+				// It has to be called on an object whose chain of `parent`s includes story-edit-view, where the handler is defined
+				// After execution, a new passage has been appended to `this.story.passages`
+				this.dispatchTo.$dispatch('passage-create');
+
+				// The new passage is always the last one in the list:
+				const newPassage = this.story.passages[this.story.passages.length-1];
+
 				// It's not enough to directly modify the passage object -- changes won't persist.
 				// We have to call updatePassage() to make permanent changes.
 				this.updatePassage(
-					this.storyId,
-					this.passageId,
+					this.story.id,
+					newPassage.id,
 					// In a perfect world, we would query the story format for how to embed an image.
 					// In practice, all the standard formats seem to use the same HTML syntax for images.
 					{ text: '<img src="'+source+'">', name: file.name, tags: ['image'] }

--- a/src/editors/passage/index.html
+++ b/src/editors/passage/index.html
@@ -10,6 +10,6 @@
 	</p>
 
 	<div class="expand">
-		<code-mirror :options="cmOptions" :text="passage.text" @cm-change="saveText" @paste="paste" v-ref:codemirror></code-mirror>
+		<code-mirror :options="cmOptions" :text="passage.text" @cm-change="saveText" @paste="onPaste" v-ref:codemirror></code-mirror>
 	</div> <!-- .fullEdit -->
 </modal-dialog>

--- a/src/editors/passage/index.html
+++ b/src/editors/passage/index.html
@@ -10,6 +10,6 @@
 	</p>
 
 	<div class="expand">
-		<code-mirror :options="cmOptions" :text="passage.text" @cm-change="saveText" v-ref:codemirror></code-mirror>
+		<code-mirror :options="cmOptions" :text="passage.text" @cm-change="saveText" @paste="paste" v-ref:codemirror></code-mirror>
 	</div> <!-- .fullEdit -->
 </modal-dialog>

--- a/src/editors/passage/index.js
+++ b/src/editors/passage/index.js
@@ -79,9 +79,9 @@ module.exports = Vue.extend({
 	},
 
 	methods: {
-		paste(event) {
+		onPaste(event) {
 			const cm = this.$refs.codemirror.$cm;
-			var items = (event.clipboardData  || event.originalEvent.clipboardData).items;
+			const items = (event.clipboardData  || event.originalEvent.clipboardData).items;
 			var blob = null;
 			for (var i = 0; i < items.length; i++) {
 				if (items[i].type.indexOf("image") === 0) {
@@ -90,7 +90,7 @@ module.exports = Vue.extend({
 				}
 			}
 			if (blob !== null) {
-				var reader = new FileReader();
+				const reader = new FileReader();
 				new Promise(resolve => {
 					reader.addEventListener('load', e => {
 						resolve(e.target.result);

--- a/src/editors/passage/index.js
+++ b/src/editors/passage/index.js
@@ -102,11 +102,6 @@ module.exports = Vue.extend({
 					cm.replaceSelection('<img src="'+source+'">', "start");
 					event.preventDefault();
 				});
-				// reader.onload = function(event) {
-				// 	cm.replaceSelection('<img src="'+event.target.result+'">', "start");
-				// 	event.preventDefault();
-				// };
-				// reader.readAsDataURL(blob);
 			}
 		},
 

--- a/src/editors/passage/index.js
+++ b/src/editors/passage/index.js
@@ -72,13 +72,44 @@ module.exports = Vue.extend({
 					passage.id !== this.passage.id
 			));
 		},
-		
+
 		autocompletions() {
 			return this.parentStory.passages.map(passage => passage.name);
 		}
 	},
 
 	methods: {
+		paste(event) {
+			const cm = this.$refs.codemirror.$cm;
+			var items = (event.clipboardData  || event.originalEvent.clipboardData).items;
+			var blob = null;
+			for (var i = 0; i < items.length; i++) {
+				if (items[i].type.indexOf("image") === 0) {
+					blob = items[i].getAsFile();
+					break;
+				}
+			}
+			if (blob !== null) {
+				var reader = new FileReader();
+				new Promise(resolve => {
+					reader.addEventListener('load', e => {
+						resolve(e.target.result);
+					});
+
+					reader.readAsDataURL(blob);
+				})
+				.then(source => {
+					cm.replaceSelection('<img src="'+source+'">', "start");
+					event.preventDefault();
+				});
+				// reader.onload = function(event) {
+				// 	cm.replaceSelection('<img src="'+event.target.result+'">', "start");
+				// 	event.preventDefault();
+				// };
+				// reader.readAsDataURL(blob);
+			}
+		},
+
 		autocomplete() {
 			this.$refs.codemirror.$cm.showHint({
 				hint: cm => {

--- a/src/story-edit-view/index.html
+++ b/src/story-edit-view/index.html
@@ -1,4 +1,4 @@
-<div id="storyEditView" :style="cssDimensions" class="{{ 'zoom-' + zoomDesc }}" @webkitmouseforcedown="onMouseForceDown" @wheel="onWheel" v-mouse-scrolling>
+<div id="storyEditView" :style="cssDimensions" class="{{ 'zoom-' + zoomDesc }}" @paste="onPaste" contenteditable="true" @webkitmouseforcedown="onMouseForceDown" @wheel="onWheel" v-mouse-scrolling>
 	<div class="passages">
 		<marquee-selector :story="story"></marquee-selector>
 		<link-arrows :passages="story.passages" :positions="passagePositions" :zoom="story.zoom"></link-arrows>

--- a/src/story-edit-view/index.js
+++ b/src/story-edit-view/index.js
@@ -336,9 +336,7 @@ module.exports = Vue.extend({
 					this_.updatePassage(
 						this_.story.id,
 						newPassage.id,
-						// In a perfect world, we would query the story format for how to embed an image.
-						// In practice, all the standard formats seem to use the same HTML syntax for images.
-						{ text: '<img src="'+source+'">', name: blob.name, tags: ['image'] }
+						{ text: source, name: blob.name, tags: ['Twine.image'] }
 					);
 
 					event.preventDefault();

--- a/src/story-edit-view/story-toolbar/story-menu/index.html
+++ b/src/story-edit-view/story-toolbar/story-menu/index.html
@@ -1,6 +1,10 @@
 <drop-down position="top left">
 	<ul class="menu">
 		<li>
+			<button @click="uploadImage">{{ 'Upload New Image'| say }}</button>
+		</li>
+
+		<li>
 			<button @click="editScript">{{ 'Edit Story JavaScript'| say }}</button>
 		</li>
 

--- a/src/story-edit-view/story-toolbar/story-menu/index.js
+++ b/src/story-edit-view/story-toolbar/story-menu/index.js
@@ -27,21 +27,12 @@ module.exports = Vue.extend({
 
 	methods: {
 		uploadImage(e) {
-			// FIXME:  move passage creation to the ImageDialog
-			// This does not return anything useful, but appears to execute synchronously.
-			// https://v1.vuejs.org/api/#vm-dispatch
-			// After execution, a new passage has been appended to `this.story.passages`
-			this.$dispatch('passage-create');
-
-			// The new passage is always the last one in the list:
-			const newPassage = this.story.passages[this.story.passages.length-1]
-
 			new ImageDialog({
 				store: this.$store,
 				data: {
-					origin: e.target,
-					passageId: newPassage.id,
-					storyId: this.story.id
+					// origin: e.target,
+					dispatchTo: this,
+					story: this.story
 				}
 			}).$mountTo(document.body);
 		},

--- a/src/story-edit-view/story-toolbar/story-menu/index.js
+++ b/src/story-edit-view/story-toolbar/story-menu/index.js
@@ -27,6 +27,7 @@ module.exports = Vue.extend({
 
 	methods: {
 		uploadImage(e) {
+			// FIXME:  move passage creation to the ImageDialog
 			// This does not return anything useful, but appears to execute synchronously.
 			// https://v1.vuejs.org/api/#vm-dispatch
 			// After execution, a new passage has been appended to `this.story.passages`

--- a/src/story-edit-view/story-toolbar/story-menu/index.js
+++ b/src/story-edit-view/story-toolbar/story-menu/index.js
@@ -25,6 +25,19 @@ module.exports = Vue.extend({
 	},
 
 	methods: {
+		uploadImage(e) {
+			console.log("This story contains "+this.story.passages.length+" passage(s).")
+			const lastPassage = this.story.passages[this.story.passages.length-1]
+			console.log("The most recently added passage had ID "+lastPassage.id)
+
+			const retval = this.$dispatch('passage-create');
+			//console.log("I requested a new passage and got: ", retval)
+
+			console.log("This story contains "+this.story.passages.length+" passage(s).")
+			const newPassage = this.story.passages[this.story.passages.length-1]
+			console.log("The most recently added passage now has ID "+newPassage.id)
+		},
+
 		editScript(e) {
 			/*
 			We have to manually inject the Vuex store, since the editors are

--- a/src/story-edit-view/story-toolbar/story-menu/index.js
+++ b/src/story-edit-view/story-toolbar/story-menu/index.js
@@ -3,6 +3,7 @@
 const escape = require('lodash.escape');
 const Vue = require('vue');
 const FormatDialog = require('../../../dialogs/story-format');
+const ImageDialog = require('../../../dialogs/image-import');
 const JavaScriptEditor = require('../../../editors/javascript');
 const StatsDialog = require('../../../dialogs/story-stats');
 const StylesheetEditor = require('../../../editors/stylesheet');
@@ -26,16 +27,22 @@ module.exports = Vue.extend({
 
 	methods: {
 		uploadImage(e) {
-			console.log("This story contains "+this.story.passages.length+" passage(s).")
-			const lastPassage = this.story.passages[this.story.passages.length-1]
-			console.log("The most recently added passage had ID "+lastPassage.id)
 
-			const retval = this.$dispatch('passage-create');
-			//console.log("I requested a new passage and got: ", retval)
+			new ImageDialog({
+				store: this.$store,
+				data: { origin: e.target }
+			}).$mountTo(document.body);
 
-			console.log("This story contains "+this.story.passages.length+" passage(s).")
+			// This does not return anything useful, but appears to execute synchronously.
+			// https://v1.vuejs.org/api/#vm-dispatch
+			// After execution, a new passage has been appended to `this.story.passages`
+			this.$dispatch('passage-create');
+
+			// The new passage is always the last one in the list:
 			const newPassage = this.story.passages[this.story.passages.length-1]
-			console.log("The most recently added passage now has ID "+newPassage.id)
+			//console.log("The most recently added passage now has ID "+newPassage.id)
+			newPassage.name = "img-"+newPassage.id
+			newPassage.text = "<img>"
 		},
 
 		editScript(e) {

--- a/src/story-edit-view/story-toolbar/story-menu/index.js
+++ b/src/story-edit-view/story-toolbar/story-menu/index.js
@@ -27,12 +27,6 @@ module.exports = Vue.extend({
 
 	methods: {
 		uploadImage(e) {
-
-			new ImageDialog({
-				store: this.$store,
-				data: { origin: e.target }
-			}).$mountTo(document.body);
-
 			// This does not return anything useful, but appears to execute synchronously.
 			// https://v1.vuejs.org/api/#vm-dispatch
 			// After execution, a new passage has been appended to `this.story.passages`
@@ -40,9 +34,15 @@ module.exports = Vue.extend({
 
 			// The new passage is always the last one in the list:
 			const newPassage = this.story.passages[this.story.passages.length-1]
-			//console.log("The most recently added passage now has ID "+newPassage.id)
-			newPassage.name = "img-"+newPassage.id
-			newPassage.text = "<img>"
+
+			new ImageDialog({
+				store: this.$store,
+				data: {
+					origin: e.target,
+					passageId: newPassage.id,
+					storyId: this.story.id
+				}
+			}).$mountTo(document.body);
 		},
 
 		editScript(e) {


### PR DESCRIPTION
This submission allows users to easily embed images directly into their Twine stories as data URIs.
It also includes a start on some developer documentation, to welcome new devs to the project.

These feature were inspired by my wife's third grade class of gifted students,
who spent this semester learning about Choose Your Own Adventure stories through Twine.
For every kid, their first request after learning to link passages was to include pictures.
The process of downloading images and then converting them to data URIs was too many steps.
Uploading images to Imgur or a similar site was equally complex, and risked exposure to inappropriate content too.

The submissions closes #114.

Three ways to insert a new image:

- Choose "Upload New Image" from the story menu.  This creates a new passage with an `<img>` element.
  The new passage is tagged with the tag "image", which doesn't do anything today, but could be useful in the future.
  The image can be displayed in another passage with `(display: "my-image.png")`.
- Copy an image to the clipboard, then paste it into the story edit view (creating a new passage).
  You may have to click on the blue grid where passages appear first, to give it the focus.
- Copy an image to the clipboard, then paste it into the passage editor, creating an `<img>` element.

Tested on:

- Chrome (68 / OS X)
- Firefox (62 / OS X)

Unsolved issues:

- Embedding many large images will quickly fill localStorage.
  Authors who need many large images will have to continue hosting them elsewhere,
  but using a few images will now be easier for beginners.
- Pasting an image in the story edit view only works after focusing the underlying DIV.
  Attaching an event handler to the BODY would probably solve this, but seemed too invasive.
- In the browsers I tested, pasted images always appear to be named "image.png".
