### PR TITLE
a11y

### DIFF
--- a/src/editors/passage/index.html
+++ b/src/editors/passage/index.html
@@ -1,6 +1,6 @@
 <modal-dialog id="passageEditModal" class="editor" :can-close="canClose" :can-widen="true" :origin="origin" @destroyed="dialogDestroyed" v-ref:modal>
 	<span slot="title">
-		<input type="text" id="passageName" placeholder="{{ 'Passage Name' | say }}" v-model="userPassageName">
+		<input type="text" id="passageName" aria-label="{{ 'Passage Name' | say }}" placeholder="{{ 'Passage Name' | say }}" v-model="userPassageName">
 	</span>
 
 	<tag-editor :passage="passage" :story-id="storyId"></tag-editor>

--- a/src/editors/passage/tag-editor/index.html
+++ b/src/editors/passage/tag-editor/index.html
@@ -1,13 +1,13 @@
 <div class="passageTags">
 	<span class="tags"></span>
 
-	<button class="subtle" type="button" @click="showNew" v-show="!newVisible"><i class="fa fa-plus"></i>
+	<button class="subtle" type="button" title="{{ 'Add tag' | say }}" @click="showNew" v-show="!newVisible"><i class="fa fa-plus"></i>
 	<!-- L10n: this is the noun form, as in tags you would apply to content. -->
 	{{ 'Tag' | say }}
 	</button>
 
 	<template v-for="tag in passage.tags" transition="fade-in-out">
-		<div class="tag label label-info {{tagColors[tag]}}">{{ tag }}<button>
+		<div class="tag label label-info {{tagColors[tag]}}">{{ tag }}<button title="{{ 'Edit tag' | say }}">
 			<i class="fa fa-caret-down"></i>
 			<tag-menu :tag="tag" :passage="passage" :story-id="storyId"></tag-menu>
 		</button></div>
@@ -17,10 +17,10 @@
 		<!-- Using a <form> allows the "required" attribute on the input to be usable. -->
 		<form @submit.prevent="addNew">
 			<!-- L10n: A noun, i.e. what a tag is named. -->
-			<input type="text" placeholder="{{ 'Tag name' | say }}" required v-el:new-name>
+			<input type="text" aria-label="{{ 'Tag name' | say }}" placeholder="{{ 'Tag name' | say }}" required v-el:new-name>
 
-			<button type="button" @click="hideNew">Cancel</button>
-			<button type="submit" class="create"><i class="fa fa-check"></i> Add</button>
+			<button type="button" @click="hideNew" title="{{ 'Cancel' | say }}">Cancel</button>
+			<button type="submit" class="create"><i class="fa fa-check" title="{{ 'Add' | say }}"></i> Add</button>
 		</form>
 	</span>
 </div>

--- a/src/editors/passage/tag-editor/tag-menu/index.html
+++ b/src/editors/passage/tag-editor/tag-menu/index.html
@@ -1,7 +1,7 @@
 <drop-down position="bottom left" class="tags">
 	<ul class="menu">
 		<li>
-			<button @click="remove">
+			<button @click="remove" title="{{ 'Remove &ldquo;%1$s&rdquo;' | say tag }}">
 				{{ 'Remove &ldquo;%1$s&rdquo;' | say tag }}
 			</button>
 		</li>

--- a/src/story-edit-view/passage-item/index.html
+++ b/src/story-edit-view/passage-item/index.html
@@ -1,5 +1,7 @@
-<div class="passage" :style="cssPosition" :class="cssClasses" @mousedown.stop="startDrag"
-	@touchstart.stop="startDrag" @dblclick.stop="edit" @mouseover="needsMenu = true">
+<div class="passage" role="button" tabindex="0" title="{{ 'Edit &ldquo;%s&rdquo;' | say passage.name }}" 
+    :style="cssPosition" :class="cssClasses" @mousedown.stop="startDrag"
+	@touchstart.stop="startDrag" @dblclick.stop="edit" @mouseover="needsMenu = true"
+    @keyup.space.prevent="edit" @keyup.enter.prevent="edit">
 	<div class="frame">
 		<div class="tags">
 			<div v-for="color in tagColors" class="{{color}}"></div>

--- a/src/story-edit-view/story-toolbar/index.html
+++ b/src/story-edit-view/story-toolbar/index.html
@@ -2,7 +2,7 @@
 	<div class="left">
 		<a v-link="'/stories'" class="home subtle" title="{{ 'Go to the story list' | say }}"><i class="fa fa-home fa-lg"></i></a>
 
-		<button class="storyName subtle">
+		<button class="storyName subtle" title="{{ 'Open the story menu' | say }}">
 			<span class="storyNameVal">{{ story.name }}</span>
 			<i class="fa fa-caret-up fa-lg"></i>
 			<story-menu :story="story"></story-menu>

--- a/src/story-edit-view/story-toolbar/story-menu/index.html
+++ b/src/story-edit-view/story-toolbar/story-menu/index.html
@@ -1,41 +1,41 @@
 <drop-down position="top left">
 	<ul class="menu">
 		<li>
-			<button @click="editScript">{{ 'Edit Story JavaScript'| say }}</button>
+			<button @click="editScript" title="{{ 'Edit Story JavaScript'| say }}">{{ 'Edit Story JavaScript'| say }}</button>
 		</li>
 
 		<li>
-			<button @click="editStyle">{{ 'Edit Story Stylesheet' | say }}</button>
+			<button @click="editStyle" title="{{ 'Edit Story Stylesheet' | say }}">{{ 'Edit Story Stylesheet' | say }}</button>
 		</li>
 
 		<li>
-			<button @click="changeFormat">{{ 'Change Story Format'| say }}</button>
+			<button @click="changeFormat" title="{{ 'Change Story Format'| say }}">{{ 'Change Story Format'| say }}</button>
 		</li>
 
 		<li>
-			<button @click="renameStory">{{ 'Rename Story' | say }}</button>
+			<button @click="renameStory" title="{{ 'Rename Story' | say }}">{{ 'Rename Story' | say }}</button>
 		</li>
 
 		<li>
-			<button @click="selectAll">{{ 'Select All Passages' | say }}</button>
+			<button @click="selectAll" title="{{ 'Select All Passages' | say }}">{{ 'Select All Passages' | say }}</button>
 		</li>
 
 		<li :class="{ checked: this.story.snapToGrid }">
-			<button @click="toggleSnap">{{ 'Snap to Grid'| say }}</button>
+			<button @click="toggleSnap" title="{{ 'Snap to Grid'| say }}">{{ 'Snap to Grid'| say }}</button>
 		</li>
 
 		<li>
-			<button @click="storyStats">{{ 'Story Statistics' | say }}</button>
+			<button @click="storyStats" title="{{ 'Story Statistics' | say }}">{{ 'Story Statistics' | say }}</button>
 		</li>
 
 		<li class="divider"></li>
 
 		<li>
-			<button @click="proofStory">{{ 'View Proofing Copy' | say }}</button>
+			<button @click="proofStory" title="{{ 'View Proofing Copy' | say }}">{{ 'View Proofing Copy' | say }}</button>
 		</li>
 
 		<li>
-			<button @click="publishStory">{{ 'Publish to File' | say }}</button>
+			<button @click="publishStory" title="{{ 'Publish to File' | say }}">{{ 'Publish to File' | say }}</button>
 		</li>
 	</ul>
 </drop-down>

--- a/src/story-edit-view/story-toolbar/story-search/index.html
+++ b/src/story-edit-view/story-toolbar/story-search/index.html
@@ -1,5 +1,5 @@
 <span class="searchContainer">
-	<input type="search" placeholder="{{ 'Quick Find' | say }}" class="searchField" v-model="search">
+	<input type="search" placeholder="{{ 'Quick Find' | say }}" aria-label="{{ 'Quick Find' | say }}" class="searchField" v-model="search">
 	<button class="subtle" title="{{ 'Find and replace across the entire story' | say }}" @click="showModal">
 		<i class="fa fa-list-alt"></i>
 	</button>

--- a/src/story-list-view/list-toolbar/index.html
+++ b/src/story-list-view/list-toolbar/index.html
@@ -46,7 +46,7 @@
 		<p>
 			{{'version' | say }} <button class="link" @click="showAbout">{{ appInfo.version }}</button>
 			<br>
-			<a href="https://twinery.org/2bugs" target="_blank"><i class="fa fa-bug"></i> {{'Report a bug' | say }}</a>
+			<a href="https://twinery.org/2bugs" target="_blank" title="{{'Report a bug' | say }}"><i class="fa fa-bug"></i> {{'Report a bug' | say }}</a>
 		</p>
 	</footer>
 </nav>

--- a/src/story-list-view/story-item/index.html
+++ b/src/story-list-view/story-item/index.html
@@ -12,7 +12,7 @@
 			</p>
 		</button>
 
-		<button>
+		<button title="{{ 'Quick actions' | say }}">
 			<i class="fa fa-cog"></i>
 			<item-menu :story="story"></item-menu>
 		</button>

--- a/src/story-list-view/story-item/item-menu/index.html
+++ b/src/story-list-view/story-item/item-menu/index.html
@@ -1,29 +1,29 @@
 <drop-down position="bottom left">
 	<ul class="menu">
 		<li>
-			<button @click="play">{{ 'Play Story' | say}}</button>
+			<button @click="play" title="{{ 'Play Story' | say}}">{{ 'Play Story' | say}}</button>
 		</li>
 
 		<li>
-			<button @click="test">{{ 'Test Story' | say}}</button>
+			<button @click="test" title="{{ 'Test Story' | say}}">{{ 'Test Story' | say}}</button>
 		</li>
 
 		<li>
-			<button @click="publish">{{ 'Publish to File' | say }}</button>
+			<button @click="publish" title="{{ 'Publish to File' | say }}">{{ 'Publish to File' | say }}</button>
 		</li>
 
 		<li>
-			<button @click="rename">{{ 'Rename Story' | say }}</button>
+			<button @click="rename" title="{{ 'Rename Story' | say }}">{{ 'Rename Story' | say }}</button>
 		</li>
 
 		<li>
-			<button @click="duplicate">{{ 'Duplicate Story' | say }}</button>
+			<button @click="duplicate" title="{{ 'Duplicate Story' | say }}">{{ 'Duplicate Story' | say }}</button>
 		</li>
 
 		<li class="divider"></li>
 
 		<li>
-			<button @click="delete">{{ 'Delete Story' | say }}</button>
+			<button @click="delete" title="{{ 'Delete Story' | say }}">{{ 'Delete Story' | say }}</button>
 		</li>
 	</ul>
 </drop-down>


### PR DESCRIPTION
- added `title` attributes to most clickables that previously lacked them that I could see
- added `aria-label` attributes to many text entry inputs
- used l10n stuff and where I could, but a few I had to make up:
  - `+ Tag` -> `Add tag`
  - tag menu arrow -> `Edit tag`
  - story main menu -> `Open the story menu`
  - story list story gear icon -> `Quick actions`
- added `role="button"` and `tabindex="0"` to passages; added spacebar and enter events to passages--not sure how wise this manner of implementing it is--feels like brute-force
- not sure how to make the dropdowns accessible, probably best suited to someone smarter than me, but a lot of the grunt work is done so screen-readers *shouldn't* just say "button" everywhere anymore 

Intended to partially address #565.