### PR TITLE
Fix for undefined stories when testing/playing from cog in story list

### DIFF
--- a/src/story-list-view/story-item/item-menu/index.js
+++ b/src/story-list-view/story-item/item-menu/index.js
@@ -14,6 +14,7 @@ const {prompt} = require('../../../dialogs/prompt');
 const locale = require('../../../locale');
 const {publishStoryWithFormat} = require('../../../data/publish');
 const save = require('../../../file/save');
+const store = require('../../../data/store');
 
 module.exports = Vue.extend({
 	template: require('./index.html'),
@@ -37,7 +38,7 @@ module.exports = Vue.extend({
 		**/
 
 		play() {
-			playStory(this.story.id);
+			playStory(store, this.story.id);
 		},
 
 		/**
@@ -47,7 +48,7 @@ module.exports = Vue.extend({
 		**/
 
 		test() {
-			testStory(this.story.id);
+			testStory(store, this.story.id);
 		},
 
 		/**


### PR DESCRIPTION
Problem exists locally and on http://twinery.org

Clicking to `Play Story` and `Test Story` in the story list both launch URLs similar to: http://twinery.org/2/#stories/undefined/play

Problem: in `item-menu/index.js`, the variable `store` was not being passed in as first argument to the [playStory()](https://github.com/klembot/twinejs/blob/develop/src/story-list-view/story-item/item-menu/index.js#L40) or testStory() methods as expected by the [corresponding functions](https://github.com/klembot/twinejs/blob/develop/src/common/launch-story.js#L38).

Solution: required `data/store` and passed in to methods, to match the [story toolbar](https://github.com/klembot/twinejs/blob/develop/src/story-edit-view/story-toolbar/index.js#L40).