### PR TITLE
fix blank lines added to styles and scripts sections on import, see #505

### DIFF
--- a/src/data/import.js
+++ b/src/data/import.js
@@ -56,16 +56,12 @@ function domToObject(storyEl, forceLastUpdate) {
 				storyEl.attributes['format-version'].value : null,
 		script:
 			Array.from(storyEl.querySelectorAll(selectors.script))
-				.reduce(
-					(src, el) => src + `${el.textContent}\n`,
-					''
-				),
+				.map(el => el.textContent)
+				.join('\n'),
 		stylesheet:
 			Array.from(storyEl.querySelectorAll(selectors.stylesheet))
-				.reduce(
-					(src, el) => src + `${el.textContent}\n`,
-					''
-				),
+				.map(el => el.textContent)
+				.join('\n'),
 		zoom:
 			storyEl.attributes.zoom ?
 				parseFloat(storyEl.attributes.zoom.value) : 1,

--- a/src/data/import.spec.js
+++ b/src/data/import.spec.js
@@ -23,9 +23,9 @@ describe('import module', () => {
 		expect(result[0].ifid).toBe('3AE380EE-4B34-4D0D-A8E2-BE624EB271C9');
 		expect(result[0].zoom).toBe(1.5);
 		expect(result[0].lastUpdate instanceof Date).toBe(true);
-		expect(result[0].script).toBe("alert('hi');\n");
+		expect(result[0].script).toBe("alert('hi');");
 		expect(result[0].stylesheet).toBe(
-			'* { color: red }\n* { color: blue }\n'
+			'* { color: red }\n* { color: blue }'
 		);
 		expect(result[0].tagColors['my-tag']).toBe('purple');
 		expect(Array.isArray(result[0].passages)).toBe(true);


### PR DESCRIPTION
+minor speedup (not that it really matters in this case, but join is faster for this operation, see https://jsbench.me/ouk13kh80v/1)