### PR TITLE
Fix story renaming in Electron version

### DIFF
--- a/src/data/file-system/index.js
+++ b/src/data/file-system/index.js
@@ -109,17 +109,11 @@ module.exports = store => {
 						s => s.id === mutation.payload[0]
 					);
 
-					function cleanupListener(s) {
-						if (s === oldStory) {
-							ipcRenderer.send('save-story', newStory);
-							ipcRenderer.removeListener(
-								'story-renamed',
-								cleanupListener
-							);
-						}
+					function afterRename(_sender) {
+						saveStory(store, state, newStory)
 					}
 
-					ipcRenderer.on('story-renamed', cleanupListener);
+					ipcRenderer.once('story-renamed', afterRename);
 					ipcRenderer.send('rename-story', oldStory, newStory);
 				} else {
 					saveStory(

--- a/src/electron/story-file.js
+++ b/src/electron/story-file.js
@@ -155,10 +155,12 @@ const StoryFile = (module.exports = {
 	*/
 
 	rename(oldStory, newStory) {
-		return fs.rename(
+		return unlockStoryDirectory()
+		.then(() => fs.rename(
 			path.join(storyDirectoryPath(), StoryFile.fileName(oldStory.name)),
 			path.join(storyDirectoryPath(), StoryFile.fileName(newStory.name))
-		);
+		))
+		.then(lockStoryDirectory);
 	}
 });
 


### PR DESCRIPTION
I've been recently hit (again) by renaming problem in electron version and decided to take a look at it. I think I fixed most problems I encountered and check other issues as well:

* #639 - now after renaming the `<title>` and `<tw-storydata name>` are updated as well
* #644 - since the story is fully renamed, it also allows further renaming after Twine restart (the problem was that the file was rename, but the story title not, so upon next attempt Twine tried to rename non-existing old file derived from unchanged story name)
* #615 - since it's random, I cannot be sure, but I've seen this behaviour before and did not see it after the change
* #676 - probably fixes that as well, although I did not check if "duplicate" works

I also noticed a problem that after first rename you could not do another because the story directory was locked and rename did not perform unlocking before calling `fs.rename`.

The main reason for the problems was the condition `if (s === oldStory)`. Since `s` here is an event it never actually matched the story, so the `save-story` event was never emitted (which is easy to tell, because it does not work with single argument anyway).

Hope this helps.