### PR TITLE
Let textareas only be vertically resized

### DIFF
--- a/src/ui/forms.less
+++ b/src/ui/forms.less
@@ -32,6 +32,7 @@ textarea, .CodeMirror {
 	border-radius: 2px;
 	box-shadow: 0 0 0 1px @color-form-line;
 	padding: @len-small;
+	resize: vertical;
 	transition: 0.2s box-shadow;
 
 	&:focus {


### PR DESCRIPTION
Hello and thank you for this delightful tool! I noticed a minor visual bug where the "search for" and "replace with" textareas could be extended beyond their container, which could result in quite confusing situations. This PR adds `resize: vertical` to textareas in the stylesheet to fix this behaviour.

Example:
![Textarea](https://user-images.githubusercontent.com/64259275/87475834-bde1c180-c625-11ea-88dc-0ff8465ba5d8.png)
