### PR TITLE
Fix the first backup not saving the correct folder when launching Twine

### DIFF
--- a/src/electron/index.js
+++ b/src/electron/index.js
@@ -86,8 +86,7 @@ function addStockWindowListeners(win) {
 app.on('ready', () => {
 	let startupTask;
 
-	backupStoryDirectory()
-		.then(() => setInterval(backupStoryDirectory, 1000 * 60 * 20))
+	loadJson('prefs.json')
 		.then(() => loadJson('prefs.json'))
 		.then(data => (global.hydrate.prefs = data))
 		.catch(e => console.warn(e.message))
@@ -95,6 +94,8 @@ app.on('ready', () => {
 			startupTask = 'loading your locale preference';
 			return loadLocale(global.hydrate.prefs);
 		})
+		.then(() => backupStoryDirectory())
+		.then(() => setInterval(backupStoryDirectory, 1000 * 60 * 20))
 		.then(() => loadJson('story-formats.json'))
 		.then(data => (global.hydrate.storyFormats = data))
 		.catch(e => console.warn(e.message))

--- a/src/electron/story-directory.js
+++ b/src/electron/story-directory.js
@@ -95,6 +95,7 @@ const StoryDirectory = (module.exports = {
 
 	backup(maxBackups = 10) {
 		console.log('Backing up story library');
+		console.log('Story path : ' + StoryDirectory.path())
 
 		const backupPath = path.join(
 			app.getPath('documents'),


### PR DESCRIPTION
The locale was loaded after performing the first backup at the launch of the application.
However, the name of the folder to backup changes depending on the locale.
This causes the first backup to be ineffective and actually pollute the backups by pruning the older ones when the new one doesn't have the content that should have been backed up in it.

The code does not pass `npm run lint` however it is caused by code that was already present in the repo.