### PR TITLE
Add arm64 architecture for linux targets

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -12,7 +12,7 @@ module.exports = {
 	files: ['electron-build/**/*', 'node_modules/**/*'],
 	linux: {
 		artifactName: `twine-${pkg.version}-linux-\${arch}.zip`,
-		target: [{arch: ['ia32', 'x64'], target: 'zip'}]
+		target: [{arch: ['ia32', 'x64', 'arm64'], target: 'zip'}]
 	},
 	mac: {
 		artifactName: `twine-${pkg.version}-macos.dmg`,


### PR DESCRIPTION
# Description

This patch enables arm64 and therefore aarch64 builds for linux systems,
allowing to run Twine on arm hardware like chrome books to develop
games.

This patch originates from a request in the FlatHub review process.

# Issues fixed

https://github.com/flathub/flathub/pull/2615#discussion_r742421050

# Credit

Please put an X in *one* of the squares below only.

[ ] I would like to be credited in the application as: ______ \
[x] I would not like my name to appear in the application credits.

# Presubmission checklist

Put an X in the squares below to indicate you've done each step.

[x] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[x] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[x] I have read and agree to abide by this project's Code of Conduct.