### PR TITLE
Use debounce instead of promise chain to throttle story saving

### DIFF
--- a/src/__mocks__/electron.ts
+++ b/src/__mocks__/electron.ts
@@ -5,6 +5,7 @@ export const app = {
 	getPath(name: string) {
 		return `mock-electron-app-path-${name}`;
 	},
+	on: jest.fn(),
 	quit: jest.fn(),
 	relaunch: jest.fn()
 };


### PR DESCRIPTION
Doing this because the promise chain implementation doesn't actually appear to block execution--shows up in fast edits in story JavaScript, for example.