### PR TITLE
Delete orphaned passages on text change

### DIFF
--- a/docs/en/src/editing-stories/editing-passages.md
+++ b/docs/en/src/editing-stories/editing-passages.md
@@ -23,6 +23,19 @@ extensions](../story-formats/extensions.md).
 Twine automatically saves your changes to a passage after you stop typing for a
 moment.
 
+## Automatically-Created Links
+
+As you enter text in a passage, Twine will detect when you've added new links.
+If the destination passage doesn't already exist, it will create an empty
+passage for you. Deleting the link will delete this empty passage.
+
+Twine won't delete an empty passage while editing if any of the criteria below are true:
+
+- It is linked to from another passage
+- It has any tags
+- It has a different size than the default
+- It is the story start 
+
 ## Text Formatting, Code, Images, Sound, Video... Basically Everything Cool
 
 You should consult the documentation of the story format you are using for how

--- a/docs/en/src/editing-stories/navigating.md
+++ b/docs/en/src/editing-stories/navigating.md
@@ -14,6 +14,19 @@ In one corner of the Story Map, you'll see three buttons showing squares of
 different sizes. These let you zoom in and out of the map, showing different
 levels of detail in your passages.
 
+## Empty Passages
+
+An empty passage is one you haven't written any text in (usually). These show up
+in the Story Map as translucent cards with a dotted border. Twine automatically
+creates and deletes empty passages when you [edit links in
+passages](./editing-passages.md).
+
+## Tags
+
+If you have [assigned colors to passage tags](tagging.md), passages with those
+tags will have a small stripe of that color at their top. Tags that do not have
+colors assigned will not show a stripe.
+
 ## The Story Start
 
 The story's start passage is drawn in the map with a green rocket icon connected

--- a/src/components/passage/__tests__/passage-card.test.tsx
+++ b/src/components/passage/__tests__/passage-card.test.tsx
@@ -44,6 +44,11 @@ describe('<PassageCard>', () => {
 	describe('when passage text is empty', () => {
 		const passage = fakePassage({text: ''});
 
+		it("gives it an 'empty' CSS class", () => {
+			renderComponent({passage});
+			expect(document.querySelector('.passage-card.empty')).toBeInTheDocument();
+		});
+
 		it('displays a touch-oriented placeholder message on a touch device', () => {
 			(detectIt as any).deviceType = 'touchOnly';
 			renderComponent({passage});

--- a/src/components/passage/passage-card.css
+++ b/src/components/passage/passage-card.css
@@ -36,6 +36,19 @@
 	overflow: ellipsis;
 }
 
+.passage-card.empty .card {
+	background: hsla(0, 100%, 100%, 0.33);
+	border: 1px dashed var(--gray);
+	box-shadow: none;
+	backdrop-filter: blur(1px);
+}
+
+.passage-card.empty.selected .card {
+	background: hsla(212, 90%, 60%, 0.1);
+	border: 1px dashed var(--blue);
+	box-shadow: none;
+}
+
 .compact-passage-cards .passage-card h2 {
 	align-items: center;
 	display: flex;
@@ -53,4 +66,12 @@
 .compact-passage-cards .passage-card .tag-stripe span {
 	border-radius: 4px;
 	height: 8px;
+}
+
+[data-app-theme='dark'] .passage-card.empty .card {
+	background: hsla(0, 100%, 100%, 0.1);
+}
+
+[data-app-theme='dark'] .passage-card.empty.selected .card {
+	background: hsla(212, 90%, 60%, 0.2);
 }

--- a/src/components/passage/passage-card.tsx
+++ b/src/components/passage/passage-card.tsx
@@ -36,8 +36,12 @@ export const PassageCard: React.FC<PassageCardProps> = React.memo(props => {
 	} = props;
 	const {t} = useTranslation();
 	const className = React.useMemo(
-		() => classNames('passage-card', {selected: passage.selected}),
-		[passage.selected]
+		() =>
+			classNames('passage-card', {
+				empty: passage.text === '' && passage.tags.length === 0,
+				selected: passage.selected
+			}),
+		[passage.selected, passage.tags.length, passage.text]
 	);
 	const container = React.useRef<HTMLDivElement>(null);
 	const excerpt = React.useMemo(() => {

--- a/src/dialogs/passage-edit/passage-toolbar.tsx
+++ b/src/dialogs/passage-edit/passage-toolbar.tsx
@@ -55,14 +55,7 @@ export const PassageToolbar: React.FC<PassageToolbarProps> = props => {
 		// existing passages, updates them, but does not see that the passage name
 		// has been updated since that hasn't happened yet.
 
-		dispatch(
-			updatePassage(
-				story,
-				passage,
-				{name},
-				{dontCreateNewlyLinkedPassages: true}
-			)
-		);
+		dispatch(updatePassage(story, passage, {name}, {dontUpdateOthers: true}));
 	}
 
 	function handleSetAsStart() {

--- a/src/routes/story-edit/toolbar/passage/passage-actions.tsx
+++ b/src/routes/story-edit/toolbar/passage/passage-actions.tsx
@@ -44,14 +44,7 @@ export const PassageActions: React.FC<PassageActionsProps> = ({
 		// existing passages, updates them, but does not see that the passage name
 		// has been updated since that hasn't happened yet.
 
-		dispatch(
-			updatePassage(
-				story,
-				passage,
-				{name},
-				{dontCreateNewlyLinkedPassages: true}
-			)
-		);
+		dispatch(updatePassage(story, passage, {name}, {dontUpdateOthers: true}));
 	}
 
 	return (

--- a/src/store/stories/action-creators/__tests__/delete-orphaned-passages.test.ts
+++ b/src/store/stories/action-creators/__tests__/delete-orphaned-passages.test.ts
@@ -1,0 +1,106 @@
+import {fakeStory} from '../../../../test-util';
+import {StoriesDispatch, StoriesState, Story} from '../../stories.types';
+import {deleteOrphanedPassages} from '../delete-orphaned-passages';
+
+describe('deleteOrphanedPassages', () => {
+	let dispatch: StoriesDispatch;
+	let dispatchMock: jest.Mock;
+	let getState: () => StoriesState;
+	let story: Story;
+
+	beforeEach(() => {
+		dispatch = jest.fn();
+		dispatchMock = dispatch as jest.Mock;
+		getState = () => [story];
+
+		// Guarantee the first passage is empty.
+
+		story = fakeStory(3);
+		story.passages[0].height = 100;
+		story.passages[0].text = '';
+		story.passages[0].tags = [];
+		story.passages[0].width = 100;
+		story.passages[1].text = `[[${story.passages[0].name}]]`;
+
+		// Guarantee it's not the start and no other links exist.
+		story.startPassage = story.passages[1].id;
+		story.passages[2].text = '';
+	});
+
+	it('deletes empty passages that were only linked to from the changed passage', () => {
+		deleteOrphanedPassages(
+			story,
+			story.passages[1],
+			'',
+			story.passages[1].text
+		)(dispatch, getState);
+		expect(dispatchMock.mock.calls).toEqual([
+			[
+				{
+					type: 'deletePassages',
+					passageIds: [story.passages[0].id],
+					storyId: story.id
+				}
+			]
+		]);
+	});
+
+	it("does not delete a passage linked to from another passage, even if it's empty", () => {
+		story.passages[2].text = `[[${story.passages[0].name}]]`;
+		deleteOrphanedPassages(
+			story,
+			story.passages[1],
+			'',
+			story.passages[1].text
+		)(dispatch, getState);
+		expect(dispatchMock).not.toBeCalled();
+	});
+
+	it("does not delete a passage that isn't empty", () => {
+		story.passages[0].text = 'not empty';
+		deleteOrphanedPassages(
+			story,
+			story.passages[1],
+			'',
+			story.passages[1].text
+		)(dispatch, getState);
+		expect(dispatchMock).not.toBeCalled();
+	});
+
+	it('does not delete a passage that is the story start', () => {
+		story.startPassage = story.passages[0].id;
+		deleteOrphanedPassages(
+			story,
+			story.passages[1],
+			'',
+			story.passages[1].text
+		)(dispatch, getState);
+		expect(dispatchMock).not.toBeCalled();
+	});
+
+	it('does not delete empty passages that have no relationship to the changed passage', () => {
+		story.passages[1].text = 'no link to passages[0]';
+		deleteOrphanedPassages(
+			story,
+			story.passages[1],
+			'',
+			story.passages[1].text
+		)(dispatch, getState);
+		expect(dispatchMock).not.toBeCalled();
+	});
+
+	it('dispatches no actions if no passages are orphaned', () => {
+		deleteOrphanedPassages(
+			story,
+			story.passages[1],
+			`${story.passages[1].text} [[a new link]]`,
+			story.passages[1].text
+		)(dispatch, getState);
+		expect(dispatchMock).not.toBeCalled();
+	});
+
+	it("throws an error if given a passage that doesn't belong to the story", () =>
+		expect(() =>
+			deleteOrphanedPassages(story, {...story.passages[1], id: 'bad'}, '', '')
+		).toThrow());
+});

--- a/src/store/stories/action-creators/delete-orphaned-passages.ts
+++ b/src/store/stories/action-creators/delete-orphaned-passages.ts
@@ -1,0 +1,69 @@
+import {Thunk} from 'react-hook-thunk-reducer';
+import {parseLinks} from '../../../util/parse-links';
+import {passageIsEmpty} from '../../../util/passage-is-empty';
+import {
+	DeletePassagesAction,
+	Passage,
+	StoriesState,
+	Story
+} from '../stories.types';
+
+/**
+ * Deletes empty, orphaned passages from a story after passage text changes. An orphan
+ * must meet all these criteria:
+ *
+ * - It is considered empty (see util/passage-is-empty.ts)
+ * - It is not the story start
+ * - It was linked previously from the passage, but is not anymore
+ * - It is only linked to from the passage whose text is changing
+ *
+ * The intent is to delete passages that were automatically created in the past,
+ * but the user has removed the link through editing without ever editing the
+ * passage.
+ */
+export function deleteOrphanedPassages(
+	story: Story,
+	passage: Passage,
+	newText: string,
+	oldText: string
+): Thunk<StoriesState, DeletePassagesAction> {
+	if (!story.passages.some(p => p.id === passage.id)) {
+		throw new Error('This passage does not belong to this story.');
+	}
+
+	return dispatch => {
+		const oldLinks = parseLinks(oldText);
+		const newLinks = parseLinks(newText);
+		const orphans = oldLinks.filter(link => !newLinks.includes(link));
+
+		const passageIds = orphans.reduce<string[]>((result, orphan) => {
+			const orphanPassage = story.passages.find(p => p.name === orphan);
+
+			// These tests are fast because they look at the passage object only.
+
+			if (
+				!orphanPassage ||
+				!passageIsEmpty(orphanPassage) ||
+				story.startPassage === orphanPassage.id
+			) {
+				return result;
+			}
+
+			// This is O(n) potentially.
+
+			if (
+				story.passages.some(
+					p => p.id !== passage.id && parseLinks(p.text).includes(orphan)
+				)
+			) {
+				return result;
+			}
+
+			return [...result, orphanPassage.id];
+		}, []);
+
+		if (passageIds.length > 0) {
+			dispatch({type: 'deletePassages', passageIds, storyId: story.id});
+		}
+	};
+}

--- a/src/util/__tests__/passage-is-empty.test.ts
+++ b/src/util/__tests__/passage-is-empty.test.ts
@@ -1,0 +1,46 @@
+import {random} from 'faker';
+import {Passage} from '../../store/stories';
+import {fakePassage} from '../../test-util';
+import {passageIsEmpty} from '../passage-is-empty';
+
+describe('passageIsEmpty', () => {
+	let passage: Passage;
+
+	beforeEach(
+		() => (passage = fakePassage({height: 100, tags: [], text: '', width: 100}))
+	);
+
+	it('returns false if the passage has any text', () => {
+		expect(passageIsEmpty({...passage, text: ' '})).toBe(false);
+		expect(passageIsEmpty({...passage, text: random.words(1)})).toBe(false);
+	});
+
+	it('returns false if the passage has any tags', () => {
+		expect(passageIsEmpty({...passage, tags: [random.words(1)]})).toBe(false);
+		expect(
+			passageIsEmpty({...passage, tags: [random.words(1), random.words(1)]})
+		).toBe(false);
+	});
+
+	it('returns false if the passage width is not 100', () => {
+		expect(passageIsEmpty({...passage, width: 50})).toBe(false);
+		expect(passageIsEmpty({...passage, width: 200})).toBe(false);
+	});
+
+	it('returns false if the passage height is not 100', () => {
+		expect(passageIsEmpty({...passage, height: 50})).toBe(false);
+		expect(passageIsEmpty({...passage, height: 200})).toBe(false);
+	});
+
+	it('returns true if the passage text is empty, has no tags, and dimensions are 100', () =>
+		expect(
+			passageIsEmpty({
+				...passage,
+				height: 100,
+				name: random.words(5),
+				width: 100,
+				tags: [],
+				text: ''
+			})
+		).toBe(true));
+});

--- a/src/util/passage-is-empty.ts
+++ b/src/util/passage-is-empty.ts
@@ -1,0 +1,14 @@
+import {Passage} from '../store/stories';
+
+/**
+ * Returns whether a passage is considered empty, e.g. whether the user has put
+ * any content into it.
+ */
+export function passageIsEmpty(passage: Passage) {
+	return (
+		passage.text === '' &&
+		passage.tags.length === 0 &&
+		passage.width === 100 &&
+		passage.height === 100
+	);
+}


### PR DESCRIPTION
For those watching at home, this is my first try at resolving the problem with automatically-created links. It also makes empty passages look different in the story map to help the user understand what passages are potentially up for deletion.

This isn't the final word on the subject and depending on user feedback, this feature might change (a lot).