### PR TITLE
Fix JS/CSS dialog height when passage stack open

### DIFF
--- a/src/dialogs/passage-edit/passage-edit-stack.css
+++ b/src/dialogs/passage-edit/passage-edit-stack.css
@@ -1,6 +1,5 @@
 .passage-edit-stack {
 	flex-grow: 1;
-	height: 100%;
 	width: 100%;
 }
 


### PR DESCRIPTION
To repro this, open either the JS or CSS dialogs while a passage editor is open.