### PR TITLE
Implement temporary file pruning

### DIFF
--- a/src/electron/main-process/__tests__/ipc.test.ts
+++ b/src/electron/main-process/__tests__/ipc.test.ts
@@ -142,7 +142,8 @@ describe('initIpc()', () => {
 		listener[1]({}, 'test-file-contents', 'test-file-suffix');
 		expect(openWithTempFileMock).toBeCalledWith(
 			'test-file-contents',
-			'test-file-suffix'
+			'test-file-suffix',
+			expect.any(Boolean)
 		);
 	});
 

--- a/src/electron/main-process/ipc.ts
+++ b/src/electron/main-process/ipc.ts
@@ -66,8 +66,8 @@ export function initIpc() {
 		}
 	});
 
-	ipcMain.on('open-with-temp-file', (event, data: string, suffix: string) =>
-		openWithTempFile(data, suffix)
+	ipcMain.on('open-with-temp-file', (event, data: string, suffix: string, delete_next: boolean=false) =>
+		openWithTempFile(data, suffix, delete_next)
 	);
 
 	// This doesn't use handle() because state reducers in the renderer process

--- a/src/electron/main-process/open-with-temp-file.ts
+++ b/src/electron/main-process/open-with-temp-file.ts
@@ -1,5 +1,5 @@
 import {app, shell} from 'electron';
-import { writeFile, remove } from 'fs-extra';
+import {writeFile, remove} from 'fs-extra';
 import path from 'path';
 import uuid from 'tiny-uuid';
 
@@ -14,7 +14,7 @@ function deleteTempFile(path: string|null, required_subroot: string) {
 	}
 }
 
-export async function openWithTempFile(data: string, suffix: string, delete_next: boolean = true) {
+export async function openWithTempFile(data: string, suffix: string, delete_next: boolean = false) {
 	const tempSubRoot: string = app.getPath('temp');
 	const tempPath: string = path.join(tempSubRoot, uuid() + suffix);
 

--- a/src/electron/main-process/open-with-temp-file.ts
+++ b/src/electron/main-process/open-with-temp-file.ts
@@ -1,11 +1,30 @@
 import {app, shell} from 'electron';
-import {writeFile} from 'fs-extra';
+import { writeFile, remove } from 'fs-extra';
 import path from 'path';
 import uuid from 'tiny-uuid';
 
-export async function openWithTempFile(data: string, suffix: string) {
-	const tempPath = path.join(app.getPath('temp'), uuid() + suffix);
+let oldtmp:string|null = null;
 
+function deleteTempFile(path: string|null, required_subroot: string) {
+	if (path != null && path.startsWith(required_subroot)) {
+		remove(path, () => {
+			oldtmp = null;
+			console.debug(`Temporary file ${path} deleted.`);
+		});
+	}
+}
+
+export async function openWithTempFile(data: string, suffix: string, delete_next: boolean = true) {
+	const tempSubRoot: string = app.getPath('temp');
+	const tempPath: string = path.join(tempSubRoot, uuid() + suffix);
+
+	deleteTempFile(oldtmp, tempSubRoot)
 	await writeFile(tempPath, data);
+	if (delete_next === true) oldtmp = tempPath;
 	shell.openPath(tempPath);
 }
+
+app.on('will-quit', () => {
+	const tempSubRoot: string = app.getPath('temp');
+	deleteTempFile(oldtmp, tempSubRoot);
+});

--- a/src/store/use-story-launch.ts
+++ b/src/store/use-story-launch.ts
@@ -27,7 +27,8 @@ export function useStoryLaunch(): UseStoryLaunchProps {
 				twineElectron.ipcRenderer.send(
 					'open-with-temp-file',
 					await publishStory(storyId),
-					'.html'
+					'.html',
+					true
 				);
 			},
 			proofStory: async storyId => {
@@ -44,7 +45,8 @@ export function useStoryLaunch(): UseStoryLaunchProps {
 						formatOptions: 'debug',
 						startId: startPassageId
 					}),
-					'.html'
+					'.html',
+					true
 				);
 			}
 		};


### PR DESCRIPTION
# Description

Prevent the accumulation of temporary story files in POSIX systems by deleting the old one when a new one is generated. In addition, delete the leftover temporary story file when the application is closed.

# Issues Fixed

[Permanent memory leak #1445](https://github.com/klembot/twinejs/issues/1445)

# Credit

Please put an X in *one* of the squares below only.

[X] I would like to be credited in the application as: Lorenzo Ancora \
[ ] I would not like my name to appear in the application credits.

# Presubmission Checklist

Put an X in the squares below to indicate you've done each step.

[X] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[X] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[X] I have read and agree to abide by this project's Code of Conduct.