### PR TITLE
Updated pt-PT locale for Twine 2.8

### DIFF
--- a/public/locales/pt-PT.json
+++ b/public/locales/pt-PT.json
@@ -256,13 +256,21 @@
 				"overwriteChoice": "Gravar as Alterações no Twine",
 				"relaunchChoice": "Usar o Ficheiro e Reiniciar"
 			},
+			"storyLibraryFolderAppPref": {
+				"detail": "O Twine tentou abrir a seguinte localização: {{path}}.",
+				"message": "Não foi possível abrir a pasta onde escolheste pôr a tua biblioteca de histórias.",
+				"useDefault": "Usar a pasta por defeito",
+				"quit": "Sair"
+			},
 			"storyDelete": "Alguma coisa correu mal ao apagarmos a história.",
 			"storyRename": "Alguma coisa correu mal ao alterarmos o título da história.",
 			"storySave": "Alguma coisa correu mal ao gravarmos a história."
 		},
 		"menuBar": {
 			"checkForUpdates": "Verificar se há atualizações...",
+			"disableHardwareAcceleration": "Desligar a aceleração de «hardware»",
 			"edit": "Editar",
+			"setStoryLibraryFolder": "Definir a pasta da biblioteca de histórias...",
 			"showDevTools": "Mostrar a Consola de Depuração",
 			"showStoryLibrary": "Mostrar a Biblioteca de Histórias",
 			"speech": "Fala",
@@ -270,6 +278,11 @@
 			"twineHelp": "Ajuda do Twine",
 			"view": "Ver"
 		},
+		"relaunchDialog": {
+			"defaultPrompt": "Esta alteração irá produzir efeitos a partir da próxima vez que iniciares o Twine.",
+			"relaunchNow": "Reiniciar agora"
+		},
+		"scratchDirectoryName": "Abandonados",
 		"storiesDirectoryName": "Histórias",
 		"updateCheck": {
 			"download": "Descarregar",


### PR DESCRIPTION
Updated pt-PT locale to be Twine 2.8 ready with the 13 new lines: 259-264, 271, 273, 281-285.

# Description

Updated pt-PT locale to be Twine 2.8 ready with the 13 new lines: 259-264, 271, 273, 281-285.

# Issues Fixed

_If you are contributing a localization, you can skip this section._

Link the issues that this PR resolves. Your PR must resolve at least one issue, and agreement must be reached in the issue on your implementation approach before opening this PR.

# Credit

Please put an X in *one* of the squares below only.

[X ] I would like to be credited in the application as: José Dias \
[ ] I would not like my name to appear in the application credits.

# Presubmission Checklist

Put an X in the squares below to indicate you've done each step.

[X ] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[ X] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[ X] I have read and agree to abide by this project's Code of Conduct.