### PR TITLE
Added data-tag attribute to passageCard

### DIFF
--- a/src/components/passage/__tests__/passage-card.test.tsx
+++ b/src/components/passage/__tests__/passage-card.test.tsx
@@ -6,7 +6,7 @@ import {fakePassage} from '../../../test-util';
 import {passageIsEmpty} from '../../../util/passage-is-empty';
 import {PassageCard, PassageCardProps} from '../passage-card';
 
-jest.mock('../../tag/tag-stripe');
+jest.mock('../../tag/tag-stripe'); 
 jest.mock('../../../util/passage-is-empty');
 
 describe('<PassageCard>', () => {
@@ -31,6 +31,15 @@ describe('<PassageCard>', () => {
 			/>
 		);
 	}
+
+	it('should have a data-tag attribute with space-separated tags', () => {
+		const tags = ['mock-tag-1', 'mock-tag-2'];
+		const passage = fakePassage({tags});
+		renderComponent({passage});
+		
+		const passageElement = screen.getByTestId('passage-card');
+		expect(passageElement).toHaveAttribute('data-tag', tags.join(' '));
+	});
 
 	it('displays the passage name', () => {
 		const passage = fakePassage();

--- a/src/components/passage/__tests__/passage-card.test.tsx
+++ b/src/components/passage/__tests__/passage-card.test.tsx
@@ -5,8 +5,9 @@ import * as React from 'react';
 import {fakePassage} from '../../../test-util';
 import {passageIsEmpty} from '../../../util/passage-is-empty';
 import {PassageCard, PassageCardProps} from '../passage-card';
+import {lorem} from 'faker';
 
-jest.mock('../../tag/tag-stripe'); 
+jest.mock('../../tag/tag-stripe');
 jest.mock('../../../util/passage-is-empty');
 
 describe('<PassageCard>', () => {
@@ -32,13 +33,23 @@ describe('<PassageCard>', () => {
 		);
 	}
 
-	it('should have a data-tag attribute with space-separated tags', () => {
-		const tags = ['mock-tag-1', 'mock-tag-2'];
+	it('should include data-passage-tag attribute with space-separated tags', () => {
+		const tags = [lorem.slug(), lorem.slug()];
 		const passage = fakePassage({tags});
 		renderComponent({passage});
-		
-		const passageElement = screen.getByTestId('passage-card');
-		expect(passageElement).toHaveAttribute('data-tag', tags.join(' '));
+
+		// eslint-disable-next-line testing-library/no-node-access
+		const passageElement=document.querySelector('.passage-card')
+		expect(passageElement).toHaveAttribute('data-passage-tag', tags.join(' '));
+	});
+
+	it('should include data-passage-tag with an empty string when passage has no tags', () => {
+		const passage = fakePassage({tags:[]});
+		renderComponent({passage});
+
+		// eslint-disable-next-line testing-library/no-node-access
+		const passageElement=document.querySelector('.passage-card')
+		expect(passageElement).toHaveAttribute('data-passage-tag', '');
 	});
 
 	it('displays the passage name', () => {

--- a/src/components/passage/__tests__/passage-card.test.tsx
+++ b/src/components/passage/__tests__/passage-card.test.tsx
@@ -40,7 +40,7 @@ describe('<PassageCard>', () => {
 
 		// eslint-disable-next-line testing-library/no-node-access
 		const passageElement=document.querySelector('.passage-card')
-		expect(passageElement).toHaveAttribute('data-passage-tag', tags.join(' '));
+		expect(passageElement).toHaveAttribute('data-passage-tags', tags.join(' '));
 	});
 
 	it('should include data-passage-tag with an empty string when passage has no tags', () => {
@@ -49,7 +49,7 @@ describe('<PassageCard>', () => {
 
 		// eslint-disable-next-line testing-library/no-node-access
 		const passageElement=document.querySelector('.passage-card')
-		expect(passageElement).toHaveAttribute('data-passage-tag', '');
+		expect(passageElement).toHaveAttribute('data-passage-tags', '');
 	});
 
 	it('displays the passage name', () => {

--- a/src/components/passage/passage-card.tsx
+++ b/src/components/passage/passage-card.tsx
@@ -107,7 +107,7 @@ export const PassageCard: React.FC<PassageCardProps> = React.memo(props => {
 			onDrag={onDrag}
 			onStop={onDragStop}
 		>
-			<div className={className} ref={container} style={style} data-tag={passage.tags.join(' ')} data-testid='passage-card'>
+			<div className={className} ref={container} style={style} data-passage-tag={passage.tags.join(' ')}>
 				<SelectableCard
 					highlighted={passage.highlighted}
 					label={passage.name}

--- a/src/components/passage/passage-card.tsx
+++ b/src/components/passage/passage-card.tsx
@@ -107,7 +107,7 @@ export const PassageCard: React.FC<PassageCardProps> = React.memo(props => {
 			onDrag={onDrag}
 			onStop={onDragStop}
 		>
-			<div className={className} ref={container} style={style} data-passage-tag={passage.tags.join(' ')}>
+			<div className={className} ref={container} style={style} data-passage-tags={passage.tags.join(' ')}>
 				<SelectableCard
 					highlighted={passage.highlighted}
 					label={passage.name}

--- a/src/components/passage/passage-card.tsx
+++ b/src/components/passage/passage-card.tsx
@@ -107,7 +107,7 @@ export const PassageCard: React.FC<PassageCardProps> = React.memo(props => {
 			onDrag={onDrag}
 			onStop={onDragStop}
 		>
-			<div className={className} ref={container} style={style}>
+			<div className={className} ref={container} style={style} data-tag={passage.tags.join(' ')} data-testid='passage-card'>
 				<SelectableCard
 					highlighted={passage.highlighted}
 					label={passage.name}


### PR DESCRIPTION
# Description
- Added passage tags to passage-card element using data-tags to enhance customizability.
- Tested the presence of data-tags.
- Included screenshots of successful execution.

# Issues Fixed

[#1438](https://github.com/klembot/twinejs/issues/1438)

# Testing
In the development of our test to validate the data-tags attribute on the passage card, we evaluated two potential selection methods. They were 'getByTestId' and 'getByText'. 

- getByTestID

  `const passageElement = screen.getByTestId('passage-card');`
- getByText

  `const passageElement = screen.getByText(passage.name).closest('.passage-card');`

We chose getByTestId over getByText because it is more reliable, and efficient and could be used to specifically target the passage card element.

## Test Results 
<img width="645" alt="testRun" src="https://github.com/klembot/twinejs/assets/50710444/0b39a434-cceb-4b2c-a3d4-db56596368a4">
<img width="1002" alt="data-taginHTML" src="https://github.com/klembot/twinejs/assets/50710444/7ac15203-65b8-455b-a36b-4028688af305">

# Credit

[X] We would like to be credited in the application as [Siham Argaw](https://github.com/sihambyte) and [Ngoc Nguyen](https://github.com/rubynguyen1510).

# Presubmission Checklist

[X] We have read this project's CONTRIBUTING file, and this PR follows the criteria laid out there. \
[X] This contribution was created by us and we have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[X] We have read and agree to abide by this project's Code of Conduct.