### PR TITLE
Fix Italian translation (components.passageCard.placeholderClick)

### DIFF
--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -24,7 +24,7 @@
 		"indentButtons": {},
 		"localStorageQuota": {},
 		"passageCard": {
-			"placeholderClick": "Clicca due colte questo passaggio per modificarlo",
+			"placeholderClick": "Clicca due volte questo passaggio per modificarlo",
 			"placeholderTouch": "Tappa questo passaggio, dopodiché l’icona della matita per modificarlo."
 		},
 		"renamePassageButton": {"emptyName": "Inserisci un nome."},


### PR DESCRIPTION
# Description

Fix the Italian translation, replacing the word "colte" with "volte" in the passage placeholder, so that it now reads "clicca due volte questo passaggio per modificarlo"

# Issues Fixed

__Localization__, related to closed issue #433 

# Credit

Please put an X in *one* of the squares below only.

[ ] I would like to be credited in the application as: ______ \
[X] I would not like my name to appear in the application credits.

# Presubmission Checklist

Put an X in the squares below to indicate you've done each step.

[X] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[X] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[X] I have read and agree to abide by this project's Code of Conduct.