### PR TITLE
Fix passage suggest to allow spaces. Closes #1176

### DIFF
--- a/src/components/control/code-area/code-area.tsx
+++ b/src/components/control/code-area/code-area.tsx
@@ -6,6 +6,7 @@ import {
 import 'codemirror/addon/display/placeholder';
 import 'codemirror/addon/hint/show-hint';
 import 'codemirror/addon/hint/show-hint.css';
+import 'codemirror/addon/search/searchcursor';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/mode/css/css';
 import 'codemirror/mode/javascript/javascript';

--- a/src/store/__tests__/use-codemirror-passage-hints.test.tsx
+++ b/src/store/__tests__/use-codemirror-passage-hints.test.tsx
@@ -10,7 +10,11 @@ describe('useCodeMirrorPassageHints()', () => {
 			findWordAt: () => ({anchor: 0, head: 0}),
 			getCursor: jest.fn(),
 			getRange: () => 'a',
-			showHint: jest.fn()
+			showHint: jest.fn(),
+			getDoc: () => ({ getSearchCursor: () => ({
+				findPrevious: jest.fn(), 
+				from: () => ({ch: 0})
+			})})
 		};
 		const story = fakeStory(3);
 
@@ -32,7 +36,11 @@ describe('useCodeMirrorPassageHints()', () => {
 			findWordAt: () => ({anchor: 0, head: 0}),
 			getCursor: jest.fn(),
 			getRange: () => 'a',
-			showHint: jest.fn()
+			showHint: jest.fn(),
+			getDoc: () => ({ getSearchCursor: () => ({
+				findPrevious: jest.fn(), 
+				from: () => ({ch: 0})
+			})})
 		};
 		const story = fakeStory(3);
 


### PR DESCRIPTION
# Description

This change makes the passage suggestion menu (when typing a link) work correctly when typing a link or passage name with a space in it.

# Issues Fixed

This change resolves issues: #1176 (and similar)

# Credit

Please put an X in *one* of the squares below only.

[X] I would like to be credited in the application as: Hituro (David Donachie) \
[ ] I would not like my name to appear in the application credits.

# Presubmission Checklist

Put an X in the squares below to indicate you've done each step.

[X] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[X] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[X] I have read and agree to abide by this project's Code of Conduct.