### PR TITLE
Issue #1586: Adding "Deselect All" Button to passages screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Twine",
-	"version": "2.9.1",
+	"version": "2.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Twine",
-			"version": "2.9.1",
+			"version": "2.10.0",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@lukeed/uuid": "^2.0.1",

--- a/public/locales/cs.json
+++ b/public/locales/cs.json
@@ -20,6 +20,7 @@
 		"custom": "Vlastní",
 		"delete": "Smazat",
 		"deleteCount": "Smazat ({{count}})",
+		"deselectAll": "Zrušit výběr",
 		"details": "Podrobnosti",
 		"duplicate": "Duplikovat",
 		"edit": "Upravit",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -20,6 +20,7 @@
 		"custom": "Custom",
 		"delete": "Löschen",
 		"deleteCount": "Lösche ({{count}})",
+		"deselectAll": "Alle Markierungen aufheben",
 		"details": "Details",
 		"duplicate": "Duplizieren",
 		"edit": "Bearbeiten",

--- a/public/locales/en-US.json
+++ b/public/locales/en-US.json
@@ -20,6 +20,7 @@
 		"custom": "Custom",
 		"delete": "Delete",
 		"deleteCount": "Delete ({{count}})",
+		"deselectAll": "Deselect All",
 		"details": "Details",
 		"duplicate": "Duplicate",
 		"edit": "Edit",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -13,6 +13,7 @@
 		"appName": "Twine",
 		"cancel": "Annuler",
 		"delete": "Supprimer",
+		"deselectAll": "Désélectionner tout",
 		"duplicate": "Dupliquer",
 		"edit": "Modifier",
 		"ok": "OK",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -20,6 +20,7 @@
 		"custom": "Personalizzato",
 		"delete": "Elimina",
 		"deleteCount": "Elimina ({{count}})",
+		"deselectAll": "Deseleziona tutto",
 		"details": "Dettagli",
 		"duplicate": "Duplicato",
 		"edit": "Modifica",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -20,6 +20,7 @@
 		"custom": "커스텀",
 		"delete": "삭제",
 		"deleteCount": "삭제 ({{count}})",
+		"deselectAll": "모두 선택 해제",
 		"details": "세부 사항",
 		"duplicate": "복제",
 		"edit": "편집",

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -20,6 +20,7 @@
 		"custom": "Aangepast",
 		"delete": "Verwijderen",
 		"deleteCount": "Verwijderen ({{count}})",
+		"deselectAll": "Deselecteer Alles",
 		"details": "Details",
 		"duplicate": "Duplicaten",
 		"edit": "Bewerken",

--- a/public/locales/pt-BR.json
+++ b/public/locales/pt-BR.json
@@ -20,6 +20,7 @@
     "custom": "Personalizado",
     "delete": "Excluir",
     "deleteCount": "Excluir ({{count}})",
+	"deselectAll": "Desmarcar Tudo",
     "details": "Detalhes",
     "duplicate": "Duplicar",
     "edit": "Editar",

--- a/public/locales/pt-PT.json
+++ b/public/locales/pt-PT.json
@@ -20,6 +20,7 @@
 		"custom": "Personalizar",
 		"delete": "Apagar",
 		"deleteCount": "Apagar ({{count}})",
+		"deselectAll": "Desmarcar Tudo",
 		"details": "Detalhes",
 		"duplicate": "Duplicar",
 		"edit": "Editar",

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -20,6 +20,7 @@
 		"custom": "Özel",
 		"delete": "Sil",
 		"deleteCount": "Sil ({{count}})",
+		"deselectAll": "Seçimi Kaldır",
 		"details": "Detaylar",
 		"duplicate": "Kopya Oluştur",
 		"edit": "Düzenle",

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -20,6 +20,7 @@
 		"custom": "Custom",
 		"delete": "Видалити",
 		"deleteCount": "Видалити ({{count}})",
+		"deselectAll": "Зняти виділення",
 		"details": "Деталі",
 		"duplicate": "Дублювати",
 		"edit": "Редагувати",

--- a/public/locales/zh-CN.json
+++ b/public/locales/zh-CN.json
@@ -20,6 +20,7 @@
 		"custom": "自定义",
 		"delete": "删除",
 		"deleteCount": "删除（{{count}}）",
+		"deselectAll": "全不选",
 		"details": "细节",
 		"duplicate": "复制",
 		"edit": "编辑",

--- a/src/routes/story-edit/toolbar/passage/__tests__/deselect-all-passages-button.test.tsx
+++ b/src/routes/story-edit/toolbar/passage/__tests__/deselect-all-passages-button.test.tsx
@@ -1,0 +1,72 @@
+import {fireEvent, render, screen, within} from '@testing-library/react';
+import {axe} from 'jest-axe';
+import * as React from 'react';
+import {useStoriesContext} from '../../../../../store/stories';
+import {
+	FakeStateProvider,
+	FakeStateProviderProps,
+	fakeStory,
+	StoryInspector
+} from '../../../../../test-util';
+import {
+	DeselectAllPassagesButton,
+	DeselectAllPassagesButtonProps
+} from '../deselect-all-passages-button';
+
+const TestDeselectAllPassagesButton: React.FC<
+	Partial<DeselectAllPassagesButtonProps>
+> = props => {
+	const {stories} = useStoriesContext();
+
+	return (
+		<DeselectAllPassagesButton
+			story={stories[0]}
+			selectedPassages={[stories[0].passages[0]]}
+			{...props}
+		/>
+	);
+};
+
+describe('<DeselectAllPassagesButton>', () => {
+	function renderComponent(
+		props?: Partial<DeselectAllPassagesButtonProps>,
+		contexts?: FakeStateProviderProps
+	) {
+		return render(
+			<FakeStateProvider {...contexts}>
+				<TestDeselectAllPassagesButton {...props} />
+				<StoryInspector />
+			</FakeStateProvider>
+		);
+	}
+
+	it('is disabled if the selectedPassages prop is empty', () => {
+		renderComponent({selectedPassages: []});
+		expect(screen.getByText('common.deselectAll')).toBeDisabled();
+	});
+
+	it('deselects all passages in the story when clicked', () => {
+		const story = fakeStory(3);
+
+		story.passages[0].selected = true;
+		story.passages[1].selected = true;
+		story.passages[2].selected = true;
+		renderComponent({story}, {stories: [story]});
+		fireEvent.click(screen.getByText('common.deselectAll'));
+
+		const passages = within(
+			screen.getByTestId('story-inspector-default')
+		).getAllByTestId(/passage-/);
+
+		expect(passages.length).toBe(3);
+		expect(
+			passages.every(passage => passage.dataset.selected === 'false')
+		).toBe(true);
+	});
+
+	it('is accessible', async () => {
+		const {container} = renderComponent();
+
+		expect(await axe(container)).toHaveNoViolations();
+	});
+});

--- a/src/routes/story-edit/toolbar/passage/deselect-all-passages-button.tsx
+++ b/src/routes/story-edit/toolbar/passage/deselect-all-passages-button.tsx
@@ -1,0 +1,29 @@
+import {IconMarqueeOff} from '@tabler/icons';
+import * as React from 'react';
+import {useTranslation} from 'react-i18next';
+import {IconButton} from '../../../../components/control/icon-button';
+import {
+	deselectAllPassages,
+	Story,
+	useStoriesContext
+} from '../../../../store/stories';
+
+export interface deselectAllPassagesButtonProps {
+	story: Story;
+}
+
+export const DeselectAllPassagesButton: React.FC<
+	deselectAllPassagesButtonProps
+> = props => {
+	const {story} = props;
+	const {dispatch} = useStoriesContext();
+	const {t} = useTranslation();
+
+	return (
+		<IconButton
+			icon={<IconMarqueeOff />}
+			label={t('common.deselectAll')}
+			onClick={() => dispatch(deselectAllPassages(story))}
+		/>
+	);
+};

--- a/src/routes/story-edit/toolbar/passage/deselect-all-passages-button.tsx
+++ b/src/routes/story-edit/toolbar/passage/deselect-all-passages-button.tsx
@@ -4,23 +4,26 @@ import {useTranslation} from 'react-i18next';
 import {IconButton} from '../../../../components/control/icon-button';
 import {
 	deselectAllPassages,
+	Passage,
 	Story,
 	useStoriesContext
 } from '../../../../store/stories';
 
-export interface deselectAllPassagesButtonProps {
+export interface DeselectAllPassagesButtonProps {
 	story: Story;
+	selectedPassages: Passage[];
 }
 
 export const DeselectAllPassagesButton: React.FC<
-	deselectAllPassagesButtonProps
+	DeselectAllPassagesButtonProps
 > = props => {
-	const {story} = props;
+	const {story, selectedPassages} = props;
 	const {dispatch} = useStoriesContext();
 	const {t} = useTranslation();
 
 	return (
 		<IconButton
+			disabled={!selectedPassages.length}
 			icon={<IconMarqueeOff />}
 			label={t('common.deselectAll')}
 			onClick={() => dispatch(deselectAllPassages(story))}

--- a/src/routes/story-edit/toolbar/passage/passage-actions.tsx
+++ b/src/routes/story-edit/toolbar/passage/passage-actions.tsx
@@ -13,6 +13,7 @@ import {DeletePassagesButton} from './delete-passages-button';
 import {EditPassagesButton} from './edit-passages-buttons';
 import {GoToPassageButton} from './go-to-passage-button';
 import {SelectAllPassagesButton} from './select-all-passages-button';
+import {DeselectAllPassagesButton} from './deselect-all-passages-button';
 import {StartAtPassageButton} from './start-at-passage-button';
 import {TestPassageButton} from './test-passage-button';
 
@@ -60,7 +61,11 @@ export const PassageActions: React.FC<PassageActionsProps> = props => {
 			<TestPassageButton passage={soloSelectedPassage} story={story} />
 			<StartAtPassageButton passage={soloSelectedPassage} story={story} />
 			<GoToPassageButton onOpenFuzzyFinder={onOpenFuzzyFinder} />
-			<SelectAllPassagesButton story={story} />
+			{story.passages.length == selectedPassages.length ? (
+				<DeselectAllPassagesButton story={story} />
+			) : (
+				<SelectAllPassagesButton story={story} />
+			)}
 		</ButtonBar>
 	);
 };

--- a/src/routes/story-edit/toolbar/passage/passage-actions.tsx
+++ b/src/routes/story-edit/toolbar/passage/passage-actions.tsx
@@ -61,11 +61,11 @@ export const PassageActions: React.FC<PassageActionsProps> = props => {
 			<TestPassageButton passage={soloSelectedPassage} story={story} />
 			<StartAtPassageButton passage={soloSelectedPassage} story={story} />
 			<GoToPassageButton onOpenFuzzyFinder={onOpenFuzzyFinder} />
-			{story.passages.length == selectedPassages.length ? (
-				<DeselectAllPassagesButton story={story} />
-			) : (
-				<SelectAllPassagesButton story={story} />
-			)}
+			<SelectAllPassagesButton story={story} />
+			<DeselectAllPassagesButton
+				story={story}
+				selectedPassages={selectedPassages}
+			/>
 		</ButtonBar>
 	);
 };


### PR DESCRIPTION
# Description

This PR adds a "Deselect All" button in the Passages tab. The button is enabled when one or more passages is selected.
It also includes adding entries for "common.deselectAll" in the localization files, for languages where an existing translation was already present ("storyImport.deselectAll").

https://github.com/user-attachments/assets/c22a1a83-4598-4c26-8d99-2eecdcb89d31


# Issues Fixed
 #1586 

# Credit

Please put an X in *one* of the squares below only.

[ ] I would like to be credited in the application as: ______ \
[ X ] I would not like my name to appear in the application credits.

# Presubmission Checklist

Put an X in the squares below to indicate you've done each step.

[ X ] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[ X ] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[ X ] I have read and agree to abide by this project's Code of Conduct.