### PR TITLE
Fix typo in selecting passages documentation

### DIFF
--- a/docs/en/src/editing-stories/selecting.md
+++ b/docs/en/src/editing-stories/selecting.md
@@ -2,7 +2,7 @@
 
 ## Selecting Passages
 
-Click or tap a single passage cardto select it. You can select multiple passage
+Click or tap a single passage card to select it. You can select multiple passage
 cards by holding the Shift or Control key while selecting a particular passage.
 To deselect while keeping the rest of your selection intact, Shift- or
 Control-click it.


### PR DESCRIPTION
# Description

Corrected a missing space in the phrase "cardto" to "card to" in the documentation. This ensures clearer instructions for users selecting passages.

# Issues Fixed

https://github.com/klembot/twinejs/issues/1575#issuecomment-3049005668

# Credit

Please put an X in *one* of the squares below only.

[x] I would like to be credited in the application as: Zack Zamiska\
[ ] I would not like my name to appear in the application credits.

# Presubmission Checklist

Put an X in the squares below to indicate you've done each step.

[x] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[x] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[x] I have read and agree to abide by this project's Code of Conduct.