### PR TITLE
Fix MUD link in README.md

### DIFF
--- a/docs/en/src/README.md
+++ b/docs/en/src/README.md
@@ -36,7 +36,7 @@ done with Twine--but you might be better-served using a different tool.
 - **Online and multiplayer play.** There have been experiments with making Twine
   games that are playable by multiple people simultaneously, but doing so
   requires a good deal of programming knowledge. There have not been many modern
-  successors to the [MUD](https://en.wikipedia.org/wiki/MUD) model, but
+  successors to the [MUD](https://en.wikipedia.org/wiki/Multi-user_dungeon) model, but
   [Seltani](http://seltani.net) is one.
 
 - **Works that involve a world model, or that use interaction models other than


### PR DESCRIPTION
# Description

This repairs a link to the multi-user dungeon article on Wikipedia. The link used to lead to a disambiguation page, now it leads to the appropriate article.

# Issues Fixed

Created PR without issue since it's a minor documentation change

# Credit

[X] I would like to be credited in the application as: fetsorn (Anton Davydov) \
[ ] I would not like my name to appear in the application credits.

# Presubmission Checklist

[X] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[X] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[X] I have read and agree to abide by this project's Code of Conduct.