### PR TITLE
Add tests for checking if builtin story format files exist from store

### DIFF
--- a/src/store/__tests__/defaults.test.tsx
+++ b/src/store/__tests__/defaults.test.tsx
@@ -1,35 +1,9 @@
-import path from "node:path";
-import fs from "node:fs";
+import { join } from "node:path";
+import { access } from "node:fs/promises";
 import { builtins } from "../story-formats/defaults";
 
-describe('Story format defaults', () => {
-  it('should have valid URLs for all builtin formats', () => {
-    const formats = builtins();
-
-    // For each story format we think we have, check if the paths exist.
-    formats.forEach(format => {
-      // Check that the path exists
-      const fullPath = path.join(__dirname, '../../../public', format.url);
-      expect(fs.existsSync(fullPath)).toBe(true);
-    });
-  });
-
-  it('should have matching folder names and versions', () => {
-    const formats = builtins();
-
-    formats.forEach(format => {
-      // Verify folder name matches expected pattern
-      const expectedFolder = `${format.name.toLowerCase()}-${format.version}`;
-      expect(format.url).toContain(expectedFolder);
-    });
-  });
-
-  it('should have no duplicate format entries', () => {
-    const formats = builtins();
-    const uniqueKeys = new Set(
-      formats.map(f => `${f.name}-${f.version}`)
-    );
-    
-    expect(uniqueKeys.size).toBe(formats.length);
+describe.each(builtins().map(format => [`${format.name} ${format.version}`, format]))('%s', (_, format) => {
+  it('exists at the path set', async () => {
+    await expect(access(join(__dirname, '../../../public', format.url))).resolves.toBeUndefined();
   });
 });

--- a/src/store/__tests__/defaults.test.tsx
+++ b/src/store/__tests__/defaults.test.tsx
@@ -2,8 +2,19 @@ import { join } from "node:path";
 import { access } from "node:fs/promises";
 import { builtins } from "../story-formats/defaults";
 
-describe.each(builtins().map(format => [`${format.name} ${format.version}`, format]))('%s', (_, format) => {
-  it('exists at the path set', async () => {
-    await expect(access(join(__dirname, '../../../public', format.url))).resolves.toBeUndefined();
+describe('Story format defaults', () => {
+  describe.each(builtins().map(format => [`${format.name} ${format.version}`, format]))('%s', (_, format) => {
+    it('exists at the path set', async () => {
+      await expect(access(join(__dirname, '../../../public', format.url))).resolves.toBeUndefined();
+    });
+  });
+
+  it('should have no duplicate format entries', () => {
+    const formats = builtins();
+    const uniqueKeys = new Set(
+      formats.map(f => `${f.name}-${f.version}`)
+    );
+    
+    expect(uniqueKeys.size).toBe(formats.length);
   });
 });

--- a/src/store/__tests__/defaults.test.tsx
+++ b/src/store/__tests__/defaults.test.tsx
@@ -1,0 +1,35 @@
+import path from "node:path";
+import fs from "node:fs";
+import { builtins } from "../story-formats/defaults";
+
+describe('Story format defaults', () => {
+  it('should have valid URLs for all builtin formats', () => {
+    const formats = builtins();
+
+    // For each story format we think we have, check if the paths exist.
+    formats.forEach(format => {
+      // Check that the path exists
+      const fullPath = path.join(__dirname, '../../../public', format.url);
+      expect(fs.existsSync(fullPath)).toBe(true);
+    });
+  });
+
+  it('should have matching folder names and versions', () => {
+    const formats = builtins();
+
+    formats.forEach(format => {
+      // Verify folder name matches expected pattern
+      const expectedFolder = `${format.name.toLowerCase()}-${format.version}`;
+      expect(format.url).toContain(expectedFolder);
+    });
+  });
+
+  it('should have no duplicate format entries', () => {
+    const formats = builtins();
+    const uniqueKeys = new Set(
+      formats.map(f => `${f.name}-${f.version}`)
+    );
+    
+    expect(uniqueKeys.size).toBe(formats.length);
+  });
+});


### PR DESCRIPTION
# Description

Based on #1633, this PR adds tests for checking if the story formats in the store match the files it expects to have.

# Issues Fixed

This doesn't fix an issue directly, but does hopefully prevent the same problem saw in adding new story format files without also updating the internal store files.

# Credit

[X] I would like to be credited in the application as: Dan Cox 

# Presubmission Checklist

Put an X in the squares below to indicate you've done each step.

[X] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[X] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[X] I have read and agree to abide by this project's Code of Conduct.