### PR TITLE
Implement browser-native autocomplete and dropdown suggestions for tags.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Twine",
-	"version": "2.11.1",
+	"version": "2.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Twine",
-			"version": "2.11.1",
+			"version": "2.10.0",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@lukeed/uuid": "^2.0.1",
@@ -5003,6 +5003,14 @@
 			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
 			"dev": true
 		},
+		"node_modules/@types/parse-json": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+			"dev": true,
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/@types/plist": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
@@ -5867,6 +5875,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/asar": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
@@ -6479,6 +6498,23 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/babel-plugin-macros": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"cosmiconfig": "^7.0.0",
+				"resolve": "^1.19.0"
+			},
+			"engines": {
+				"node": ">=10",
+				"npm": ">=6"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
@@ -7831,6 +7867,36 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/camelcase-keys": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+			"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"camelcase": "^5.3.1",
+				"map-obj": "^4.0.0",
+				"quick-lru": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/camelcase-keys/node_modules/quick-lru": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001638",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001638.tgz",
@@ -8200,6 +8266,24 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
 			"dev": true
+		},
+		"node_modules/cosmiconfig": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/cp-file": {
 			"version": "10.0.0",
@@ -8721,6 +8805,46 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/decamelize-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"decamelize": "^1.1.0",
+				"map-obj": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decamelize-keys/node_modules/map-obj": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+			"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/decimal.js": {
@@ -11292,6 +11416,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/hard-rejection": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -12122,6 +12257,17 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-potential-custom-element-name": {
@@ -14899,6 +15045,17 @@
 				"json-buffer": "3.0.1"
 			}
 		},
+		"node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -15100,6 +15257,20 @@
 				"tmpl": "1.0.5"
 			}
 		},
+		"node_modules/map-obj": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/matcher": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -15144,6 +15315,76 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.10.0"
+			}
+		},
+		"node_modules/meow": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+			"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/minimist": "^1.2.0",
+				"camelcase-keys": "^6.2.2",
+				"decamelize": "^1.2.0",
+				"decamelize-keys": "^1.1.0",
+				"hard-rejection": "^2.1.0",
+				"minimist-options": "4.1.0",
+				"normalize-package-data": "^3.0.0",
+				"read-pkg-up": "^7.0.1",
+				"redent": "^3.0.0",
+				"trim-newlines": "^3.0.0",
+				"type-fest": "^0.18.0",
+				"yargs-parser": "^20.2.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/normalize-package-data": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"hosted-git-info": "^4.0.1",
+				"is-core-module": "^2.5.0",
+				"semver": "^7.3.4",
+				"validate-npm-package-license": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/meow/node_modules/type-fest": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+			"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -15283,6 +15524,22 @@
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minimist-options": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"arrify": "^1.0.1",
+				"is-plain-obj": "^1.1.0",
+				"kind-of": "^6.0.3"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/minipass": {
@@ -18589,6 +18846,17 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/trim-newlines": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -20126,6 +20394,17 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true
+		},
+		"node_modules/yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/yargs": {
 			"version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "Twine",
-	"version": "2.10.0",
+	"version": "2.11.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "Twine",
-			"version": "2.10.0",
+			"version": "2.11.1",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@lukeed/uuid": "^2.0.1",
@@ -5003,14 +5003,6 @@
 			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
 			"dev": true
 		},
-		"node_modules/@types/parse-json": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-			"dev": true,
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/@types/plist": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
@@ -5875,17 +5867,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/asar": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/asar/-/asar-3.2.0.tgz",
@@ -6498,23 +6479,6 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/babel-plugin-macros": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@babel/runtime": "^7.12.5",
-				"cosmiconfig": "^7.0.0",
-				"resolve": "^1.19.0"
-			},
-			"engines": {
-				"node": ">=10",
-				"npm": ">=6"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
@@ -7867,36 +7831,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/camelcase-keys": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-			"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"camelcase": "^5.3.1",
-				"map-obj": "^4.0.0",
-				"quick-lru": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/camelcase-keys/node_modules/quick-lru": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/caniuse-lite": {
 			"version": "1.0.30001638",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001638.tgz",
@@ -8266,24 +8200,6 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
 			"dev": true
-		},
-		"node_modules/cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/cp-file": {
 			"version": "10.0.0",
@@ -8805,46 +8721,6 @@
 				"supports-color": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decamelize-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decamelize-keys/node_modules/map-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/decimal.js": {
@@ -11416,17 +11292,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/hard-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -12257,17 +12122,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-potential-custom-element-name": {
@@ -15045,17 +14899,6 @@
 				"json-buffer": "3.0.1"
 			}
 		},
-		"node_modules/kind-of": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -15257,20 +15100,6 @@
 				"tmpl": "1.0.5"
 			}
 		},
-		"node_modules/map-obj": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/matcher": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -15315,76 +15144,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.10.0"
-			}
-		},
-		"node_modules/meow": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-			"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/minimist": "^1.2.0",
-				"camelcase-keys": "^6.2.2",
-				"decamelize": "^1.2.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.0",
-				"read-pkg-up": "^7.0.1",
-				"redent": "^3.0.0",
-				"trim-newlines": "^3.0.0",
-				"type-fest": "^0.18.0",
-				"yargs-parser": "^20.2.3"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/meow/node_modules/type-fest": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-			"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/meow/node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -15524,22 +15283,6 @@
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/minimist-options": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0",
-				"kind-of": "^6.0.3"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/minipass": {
@@ -18846,17 +18589,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/trim-newlines": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/trim-right": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -20394,17 +20126,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true
-		},
-		"node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"dev": true,
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 6"
-			}
 		},
 		"node_modules/yargs": {
 			"version": "17.7.2",

--- a/src/components/control/__mocks__/autocomplete-text-input.tsx
+++ b/src/components/control/__mocks__/autocomplete-text-input.tsx
@@ -1,37 +1,27 @@
 import * as React from 'react';
-import {AutocompleteTextInputProps} from '../autocomplete-text-input';
+import type {AutocompleteTextInputProps} from '../autocomplete-text-input';
 import {TextInput} from '../text-input';
+
+// Invisible separator used to detect datalist selection. Also defined here to prevent circular dependency.
+const DATALIST_SELECTION_MARKER = '\u2063';
 
 export const AutocompleteTextInput: React.FC<AutocompleteTextInputProps> = ({
 	children,
 	completions,
 	id,
-	onSelect,
 	...rest
-}) => {
-	function handleInput(event: React.FormEvent<HTMLInputElement>) {
-		const target = event.target as HTMLInputElement;
-
-		// Check if user selected from datalist (value ends with invisible separator)
-		if (target.value.endsWith('\u2063')) {
-			const cleanValue = target.value.slice(0, -1);
-			target.value = cleanValue;
-			onSelect?.(cleanValue);
-		}
-
-		rest.onInput?.(event);
-	}
-
-	return (
-		<>
-			<TextInput id={id} list={`${id}-datalist`} {...rest} onInput={handleInput}>
-				<span data-completions={JSON.stringify(completions)}>{children}</span>
-			</TextInput>
-			<datalist id={`${id}-datalist`}>
-				{completions.map(completion => (
-					<option key={completion} value={completion + '\u2063'} />
-				))}
-			</datalist>
-		</>
-	);
-};
+}) => (
+	<>
+		<TextInput id={id} list={`${id}-datalist`} {...rest}>
+			<span data-completions={JSON.stringify(completions)}>{children}</span>
+		</TextInput>
+		<datalist id={`${id}-datalist`}>
+			{completions.map(completion => (
+				<option
+					key={completion}
+					value={completion + DATALIST_SELECTION_MARKER}
+				/>
+			))}
+		</datalist>
+	</>
+);

--- a/src/components/control/__mocks__/autocomplete-text-input.tsx
+++ b/src/components/control/__mocks__/autocomplete-text-input.tsx
@@ -7,7 +7,14 @@ export const AutocompleteTextInput: React.FC<AutocompleteTextInputProps> = ({
 	completions,
 	...rest
 }) => (
-	<TextInput {...rest}>
-		<span data-completions={JSON.stringify(completions)}>{children}</span>
-	</TextInput>
+	<>
+		<TextInput list="mock-datalist-id" {...rest}>
+			<span data-completions={JSON.stringify(completions)}>{children}</span>
+		</TextInput>
+		<datalist id="mock-datalist-id">
+			{completions.map(completion => (
+				<option key={completion} value={completion} />
+			))}
+		</datalist>
+	</>
 );

--- a/src/components/control/__mocks__/autocomplete-text-input.tsx
+++ b/src/components/control/__mocks__/autocomplete-text-input.tsx
@@ -5,13 +5,14 @@ import {TextInput} from '../text-input';
 export const AutocompleteTextInput: React.FC<AutocompleteTextInputProps> = ({
 	children,
 	completions,
+	id,
 	...rest
 }) => (
 	<>
-		<TextInput list="mock-datalist-id" {...rest}>
+		<TextInput list={`${id}-datalist`} {...rest}>
 			<span data-completions={JSON.stringify(completions)}>{children}</span>
 		</TextInput>
-		<datalist id="mock-datalist-id">
+		<datalist id={`${id}-datalist`}>
 			{completions.map(completion => (
 				<option key={completion} value={completion} />
 			))}

--- a/src/components/control/__mocks__/autocomplete-text-input.tsx
+++ b/src/components/control/__mocks__/autocomplete-text-input.tsx
@@ -9,7 +9,7 @@ export const AutocompleteTextInput: React.FC<AutocompleteTextInputProps> = ({
 	...rest
 }) => (
 	<>
-		<TextInput list={`${id}-datalist`} {...rest}>
+		<TextInput id={id} list={`${id}-datalist`} {...rest}>
 			<span data-completions={JSON.stringify(completions)}>{children}</span>
 		</TextInput>
 		<datalist id={`${id}-datalist`}>

--- a/src/components/control/__mocks__/autocomplete-text-input.tsx
+++ b/src/components/control/__mocks__/autocomplete-text-input.tsx
@@ -6,16 +6,32 @@ export const AutocompleteTextInput: React.FC<AutocompleteTextInputProps> = ({
 	children,
 	completions,
 	id,
+	onSelect,
 	...rest
-}) => (
-	<>
-		<TextInput id={id} list={`${id}-datalist`} {...rest}>
-			<span data-completions={JSON.stringify(completions)}>{children}</span>
-		</TextInput>
-		<datalist id={`${id}-datalist`}>
-			{completions.map(completion => (
-				<option key={completion} value={completion} />
-			))}
-		</datalist>
-	</>
-);
+}) => {
+	function handleInput(event: React.FormEvent<HTMLInputElement>) {
+		const target = event.target as HTMLInputElement;
+
+		// Check if user selected from datalist (value ends with invisible separator)
+		if (target.value.endsWith('\u2063')) {
+			const cleanValue = target.value.slice(0, -1);
+			target.value = cleanValue;
+			onSelect?.(cleanValue);
+		}
+
+		rest.onInput?.(event);
+	}
+
+	return (
+		<>
+			<TextInput id={id} list={`${id}-datalist`} {...rest} onInput={handleInput}>
+				<span data-completions={JSON.stringify(completions)}>{children}</span>
+			</TextInput>
+			<datalist id={`${id}-datalist`}>
+				{completions.map(completion => (
+					<option key={completion} value={completion + '\u2063'} />
+				))}
+			</datalist>
+		</>
+	);
+};

--- a/src/components/control/__mocks__/autocomplete-text-input.tsx
+++ b/src/components/control/__mocks__/autocomplete-text-input.tsx
@@ -2,26 +2,13 @@ import * as React from 'react';
 import type {AutocompleteTextInputProps} from '../autocomplete-text-input';
 import {TextInput} from '../text-input';
 
-// Invisible separator used to detect datalist selection. Also defined here to prevent circular dependency.
-const DATALIST_SELECTION_MARKER = '\u2063';
-
 export const AutocompleteTextInput: React.FC<AutocompleteTextInputProps> = ({
 	children,
 	completions,
 	id,
 	...rest
 }) => (
-	<>
-		<TextInput id={id} list={`${id}-datalist`} {...rest}>
-			<span data-completions={JSON.stringify(completions)}>{children}</span>
-		</TextInput>
-		<datalist id={`${id}-datalist`}>
-			{completions.map(completion => (
-				<option
-					key={completion}
-					value={completion + DATALIST_SELECTION_MARKER}
-				/>
-			))}
-		</datalist>
-	</>
+	<TextInput id={id} list={`${id}-datalist`} {...rest}>
+		<span data-completions={JSON.stringify(completions)}>{children}</span>
+	</TextInput>
 );

--- a/src/components/control/__tests__/autocomplete-text-input.test.tsx
+++ b/src/components/control/__tests__/autocomplete-text-input.test.tsx
@@ -16,7 +16,6 @@ function AutocompleteTextInputDemo(
 			completions={props.completions}
 			id={props.id}
 			onChange={event => setValue(event.target.value)}
-			onSelect={props.onSelect}
 			value={value}
 		>
 			children
@@ -77,7 +76,6 @@ describe('<AutocompleteTextInput>', () => {
 			target: {selectionStart: 1, selectionEnd: 1, value: 't'}
 		});
 		expect(field).toHaveValue('test');
-		// Selection doesn't seem to be set correctly in our test DOM.
 	});
 
 	it('autocompletes with case-insensitive matching', () => {
@@ -185,46 +183,6 @@ describe('<AutocompleteTextInput>', () => {
 		expect(field.getAttribute('list')).toBe('tag-input-datalist');
 		expect(datalist).toBeInTheDocument();
 		expect(datalist?.id).toBe('tag-input-datalist');
-	});
-
-	it('calls onSelect when a datalist option is selected', () => {
-		const onSelect = jest.fn();
-		renderComponent({
-			completions: ['apple', 'banana'],
-			onSelect,
-			value: ''
-		});
-
-		const field = screen.getByRole('combobox');
-
-		fireEvent.input(field, {
-			target: {
-				selectionStart: 5,
-				selectionEnd: 5,
-				value: 'apple\u2063'
-			}
-		});
-
-		expect(onSelect).toHaveBeenCalledWith('apple');
-		expect(field).toHaveValue('apple');
-	});
-
-	it('does not call onSelect when typing normally', () => {
-		const onSelect = jest.fn();
-		renderComponent({
-			completions: ['apple', 'banana'],
-			onSelect,
-			value: ''
-		});
-
-		const field = screen.getByRole('combobox');
-
-		fireEvent.input(field, {
-			data: 'a',
-			target: {selectionStart: 1, selectionEnd: 1, value: 'a'}
-		});
-
-		expect(onSelect).not.toHaveBeenCalled();
 	});
 
 	it('is accessible', async () => {

--- a/src/components/control/__tests__/autocomplete-text-input.test.tsx
+++ b/src/components/control/__tests__/autocomplete-text-input.test.tsx
@@ -119,9 +119,9 @@ describe('<AutocompleteTextInput>', () => {
 		const datalist = document.querySelector('datalist');
 
 		expect(datalist).toBeInTheDocument();
-		expect(datalist?.querySelectorAll('option')).toHaveLength(3);
-
-		const options = Array.from(datalist?.querySelectorAll('option') || []);
+		const options = datalist.querySelectorAll('option');
+		
+		expect(options).toHaveLength(3);
 
 		expect(options[0].value).toBe('apple');
 		expect(options[1].value).toBe('banana');

--- a/src/components/control/__tests__/autocomplete-text-input.test.tsx
+++ b/src/components/control/__tests__/autocomplete-text-input.test.tsx
@@ -135,9 +135,7 @@ describe('<AutocompleteTextInput>', () => {
 		const datalist = document.querySelector('datalist');
 		expect(datalist).toBeInTheDocument();
 
-		const listId = input.getAttribute('list');
-		expect(listId).toBeTruthy();
-		expect(datalist?.id).toBe(listId);
+		expect(datalist.id).toBe(input.getAttribute('list'));
 	});
 
 	it('renders an empty datalist when no completions are provided', () => {

--- a/src/components/control/__tests__/autocomplete-text-input.test.tsx
+++ b/src/components/control/__tests__/autocomplete-text-input.test.tsx
@@ -6,10 +6,20 @@ import {
 	AutocompleteTextInputProps
 } from '../autocomplete-text-input';
 
-function AutocompleteTextInputDemo(props: Omit<AutocompleteTextInputProps, 'children' | 'onChange'>) {
+function AutocompleteTextInputDemo(
+	props: Omit<AutocompleteTextInputProps, 'children' | 'onChange'>
+) {
 	const [value, setValue] = React.useState(props.value);
 
-	return <AutocompleteTextInput onChange={event => setValue(event.target.value)} value={value} completions={props.completions}>children</AutocompleteTextInput>;
+	return (
+		<AutocompleteTextInput
+			completions={props.completions}
+			onChange={event => setValue(event.target.value)}
+			value={value}
+		>
+			children
+		</AutocompleteTextInput>
+	);
 }
 
 describe('<AutocompleteTextInput>', () => {
@@ -26,7 +36,7 @@ describe('<AutocompleteTextInput>', () => {
 	it('renders a text input with the value set', () => {
 		renderComponent({value: 'test-value'});
 
-		const field = screen.getByRole('textbox');
+		const field = screen.getByRole('combobox');
 
 		expect(field).toBeInTheDocument();
 		expect(field.getAttribute('value')).toBe('test-value');
@@ -35,7 +45,7 @@ describe('<AutocompleteTextInput>', () => {
 	it("allows typing in a value that doesn't match any completions", () => {
 		renderComponent({completions: ['test'], value: 'test-value'});
 
-		const field = screen.getByRole('textbox');
+		const field = screen.getByRole('combobox');
 
 		fireEvent.input(field, {
 			data: 'a',
@@ -57,7 +67,7 @@ describe('<AutocompleteTextInput>', () => {
 	it('autocompletes the first match when the input changes and the cursor is at the end', () => {
 		renderComponent({completions: ['test'], value: ''});
 
-		const field = screen.getByRole('textbox');
+		const field = screen.getByRole('combobox');
 
 		fireEvent.input(field, {
 			data: 't',
@@ -70,7 +80,7 @@ describe('<AutocompleteTextInput>', () => {
 	it('only autocompletes case-sensitive matches', () => {
 		renderComponent({completions: ['test'], value: ''});
 
-		const field = screen.getByRole('textbox');
+		const field = screen.getByRole('combobox');
 
 		fireEvent.input(field, {
 			data: 'T',
@@ -82,7 +92,7 @@ describe('<AutocompleteTextInput>', () => {
 	it("doesn't autocomplete if the cursor is not at the end of the field", () => {
 		renderComponent({completions: ['test'], value: 'ts'});
 
-		const field = screen.getByRole('textbox');
+		const field = screen.getByRole('combobox');
 
 		fireEvent.input(field, {
 			data: 'e',
@@ -94,13 +104,49 @@ describe('<AutocompleteTextInput>', () => {
 	it("doesn't autocomplete if there is text selected", () => {
 		renderComponent({completions: ['test'], value: 'te'});
 
-		const field = screen.getByRole('textbox');
+		const field = screen.getByRole('combobox');
 
 		fireEvent.input(field, {
 			data: 's',
 			target: {selectionStart: 0, selectionEnd: 1, value: 'tes'}
 		});
 		expect(field).toHaveValue('tes');
+	});
+
+	it('renders a datalist with autocomplete', () => {
+		renderComponent({completions: ['apple', 'banana', 'cherry']});
+
+		const datalist = document.querySelector('datalist');
+
+		expect(datalist).toBeInTheDocument();
+		expect(datalist?.querySelectorAll('option')).toHaveLength(3);
+
+		const options = Array.from(datalist?.querySelectorAll('option') || []);
+
+		expect(options[0].value).toBe('apple');
+		expect(options[1].value).toBe('banana');
+		expect(options[2].value).toBe('cherry');
+	});
+
+	it('connects the input to the datalist via list attribute', () => {
+		renderComponent({completions: ['test']});
+
+		const input = screen.getByRole('combobox');
+		const datalist = document.querySelector('datalist');
+		expect(datalist).toBeInTheDocument();
+
+		const listId = input.getAttribute('list');
+		expect(listId).toBeTruthy();
+		expect(datalist?.id).toBe(listId);
+	});
+
+	it('renders an empty datalist when no completions are provided', () => {
+		renderComponent({completions: []});
+
+		const datalist = document.querySelector('datalist');
+
+		expect(datalist).toBeInTheDocument();
+		expect(datalist?.querySelectorAll('option')).toHaveLength(0);
 	});
 
 	it('is accessible', async () => {

--- a/src/components/control/__tests__/autocomplete-text-input.test.tsx
+++ b/src/components/control/__tests__/autocomplete-text-input.test.tsx
@@ -14,6 +14,7 @@ function AutocompleteTextInputDemo(
 	return (
 		<AutocompleteTextInput
 			completions={props.completions}
+			id={props.id}
 			onChange={event => setValue(event.target.value)}
 			value={value}
 		>
@@ -27,6 +28,7 @@ describe('<AutocompleteTextInput>', () => {
 		return render(
 			<AutocompleteTextInputDemo
 				completions={[]}
+				id="test-autocomplete"
 				value="mock-value"
 				{...props}
 			/>
@@ -119,32 +121,23 @@ describe('<AutocompleteTextInput>', () => {
 		const datalist = document.querySelector('datalist');
 
 		expect(datalist).toBeInTheDocument();
-		const options = datalist.querySelectorAll('option');
 		
+		const options = datalist!.querySelectorAll('option');
 		expect(options).toHaveLength(3);
-
 		expect(options[0].value).toBe('apple');
 		expect(options[1].value).toBe('banana');
 		expect(options[2].value).toBe('cherry');
 	});
 
-	it('connects the input to the datalist via list attribute', () => {
-		renderComponent({completions: ['test']});
+	it('uses the id prop to generate the datalist id', () => {
+		renderComponent({id: 'tag-input', completions: ['test']});
 
-		const input = screen.getByRole('combobox');
-		const datalist = document.querySelector('datalist');
+		const field = screen.getByRole('combobox');
+		const datalist = document.querySelector('#tag-input-datalist');
+
+		expect(field.getAttribute('list')).toBe('tag-input-datalist');
 		expect(datalist).toBeInTheDocument();
-
-		expect(datalist.id).toBe(input.getAttribute('list'));
-	});
-
-	it('renders an empty datalist when no completions are provided', () => {
-		renderComponent({completions: []});
-
-		const datalist = document.querySelector('datalist');
-
-		expect(datalist).toBeInTheDocument();
-		expect(datalist?.querySelectorAll('option')).toHaveLength(0);
+		expect(datalist?.id).toBe('tag-input-datalist');
 	});
 
 	it('is accessible', async () => {

--- a/src/components/control/autocomplete-text-input.tsx
+++ b/src/components/control/autocomplete-text-input.tsx
@@ -5,10 +5,17 @@ export interface AutocompleteTextInputProps extends TextInputProps {
 	completions: string[];
 }
 
+let uniqueIdCounter = 0;
+
 export const AutocompleteTextInput = React.forwardRef<
 	HTMLInputElement,
 	AutocompleteTextInputProps
 >((props, ref) => {
+	const datalistId = React.useMemo(
+		() => `autocomplete-datalist-${++uniqueIdCounter}`,
+		[]
+	);
+
 	function handleInput(event: React.FormEvent<HTMLInputElement>) {
 		const target = event.target as HTMLInputElement;
 
@@ -32,7 +39,8 @@ export const AutocompleteTextInput = React.forwardRef<
 		);
 
 		if (match) {
-			// Set the input value to the match and select the part the user didn't enter.
+			// Set the input value to the match and select the part the user
+			// didn't enter.
 
 			const originalValue = target.value;
 
@@ -43,5 +51,19 @@ export const AutocompleteTextInput = React.forwardRef<
 		props.onInput?.(event);
 	}
 
-	return <TextInput onInput={handleInput} ref={ref} {...props} />;
+	return (
+		<>
+			<TextInput
+				list={datalistId}
+				onInput={handleInput}
+				ref={ref}
+				{...props}
+			/>
+			<datalist id={datalistId}>
+				{props.completions.map(completion => (
+					<option key={completion} value={completion} />
+				))}
+			</datalist>
+		</>
+	);
 });

--- a/src/components/control/autocomplete-text-input.tsx
+++ b/src/components/control/autocomplete-text-input.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import {TextInput, TextInputProps} from './text-input';
 
+// Invisible separator used to detect datalist selection
+export const DATALIST_SELECTION_MARKER = '\u2063';
+
 export interface AutocompleteTextInputProps extends TextInputProps {
 	completions: string[];
 	id: string;
-	onSelect?: (value: string) => void;
 }
 
 export const AutocompleteTextInput = React.forwardRef<
@@ -16,11 +18,7 @@ export const AutocompleteTextInput = React.forwardRef<
 	function handleInput(event: React.FormEvent<HTMLInputElement>) {
 		const target = event.target as HTMLInputElement;
 
-		// Detect datalist selection via invisible separator (U+2063)
-		if (target.value.endsWith('\u2063')) {
-			const cleanValue = target.value.slice(0, -1);
-			target.value = cleanValue;
-			props.onSelect?.(cleanValue);
+		if (target.value.endsWith(DATALIST_SELECTION_MARKER)) {
 			props.onInput?.(event);
 			return;
 		}
@@ -69,7 +67,10 @@ export const AutocompleteTextInput = React.forwardRef<
 			/>
 			<datalist id={datalistId}>
 				{props.completions.map(completion => (
-					<option key={completion} value={completion + '\u2063'} />
+					<option
+						key={completion}
+						value={completion + DATALIST_SELECTION_MARKER}
+					/>
 				))}
 			</datalist>
 		</>

--- a/src/components/control/autocomplete-text-input.tsx
+++ b/src/components/control/autocomplete-text-input.tsx
@@ -3,18 +3,14 @@ import {TextInput, TextInputProps} from './text-input';
 
 export interface AutocompleteTextInputProps extends TextInputProps {
 	completions: string[];
+	id: string;
 }
-
-let uniqueIdCounter = 0;
 
 export const AutocompleteTextInput = React.forwardRef<
 	HTMLInputElement,
 	AutocompleteTextInputProps
 >((props, ref) => {
-	const datalistId = React.useMemo(
-		() => `autocomplete-datalist-${++uniqueIdCounter}`,
-		[]
-	);
+	const datalistId = `${props.id}-datalist`;
 
 	function handleInput(event: React.FormEvent<HTMLInputElement>) {
 		const target = event.target as HTMLInputElement;
@@ -54,8 +50,6 @@ export const AutocompleteTextInput = React.forwardRef<
 	return (
 		<>
 			<TextInput
-				// Disable browser autofill so only datalist options appear (no email/address suggestions)
-				autoComplete="off"
 				list={datalistId}
 				onInput={handleInput}
 				ref={ref}

--- a/src/components/control/autocomplete-text-input.tsx
+++ b/src/components/control/autocomplete-text-input.tsx
@@ -38,8 +38,9 @@ export const AutocompleteTextInput = React.forwardRef<
 			return;
 		}
 
-		// Only autocomplete when there's exactly one match to avoid
-		// conflicts with the datalist dropdown
+		// Only autocomplete with exactly one match. Multiple matches would fill
+		// the input with the first match and prevent the datalist dropdown from
+		// showing all available options.
 		const matches = props.completions.filter(completion =>
 			completion.toLowerCase().startsWith(target.value.toLowerCase())
 		);

--- a/src/components/control/autocomplete-text-input.tsx
+++ b/src/components/control/autocomplete-text-input.tsx
@@ -54,6 +54,8 @@ export const AutocompleteTextInput = React.forwardRef<
 	return (
 		<>
 			<TextInput
+				// Disable browser autofill so only datalist options appear (no email/address suggestions)
+				autoComplete="off"
 				list={datalistId}
 				onInput={handleInput}
 				ref={ref}

--- a/src/components/control/autocomplete-text-input.tsx
+++ b/src/components/control/autocomplete-text-input.tsx
@@ -30,13 +30,7 @@ export const AutocompleteTextInput = React.forwardRef<
 		if (target.value.endsWith(DATALIST_SELECTION_MARKER)) {
 			// User selected from datalist. Strip the marker and notify with metadata.
 			const cleanedValue = target.value.slice(0, -1);
-			
-			// Create a new event with the cleaned value
-			Object.defineProperty(event, 'target', {
-				writable: true,
-				value: {...target, value: cleanedValue}
-			});
-			
+			target.value = cleanedValue;
 			props.onChange?.(event, {autocompleted: true});
 			return;
 		}

--- a/src/components/control/autocomplete-text-input.tsx
+++ b/src/components/control/autocomplete-text-input.tsx
@@ -2,11 +2,20 @@ import * as React from 'react';
 import {TextInput, TextInputProps} from './text-input';
 
 // Invisible separator used to detect datalist selection
-export const DATALIST_SELECTION_MARKER = '\u2063';
+const DATALIST_SELECTION_MARKER = '\u2063';
 
-export interface AutocompleteTextInputProps extends TextInputProps {
+export interface AutocompleteMetadata {
+	autocompleted: boolean;
+}
+
+export interface AutocompleteTextInputProps
+	extends Omit<TextInputProps, 'onChange'> {
 	completions: string[];
 	id: string;
+	onChange?: (
+		event: React.ChangeEvent<HTMLInputElement>,
+		metadata?: AutocompleteMetadata
+	) => void;
 }
 
 export const AutocompleteTextInput = React.forwardRef<
@@ -14,6 +23,26 @@ export const AutocompleteTextInput = React.forwardRef<
 	AutocompleteTextInputProps
 >((props, ref) => {
 	const datalistId = `${props.id}-datalist`;
+
+	function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+		const target = event.target;
+
+		if (target.value.endsWith(DATALIST_SELECTION_MARKER)) {
+			// User selected from datalist. Strip the marker and notify with metadata.
+			const cleanedValue = target.value.slice(0, -1);
+			
+			// Create a new event with the cleaned value
+			Object.defineProperty(event, 'target', {
+				writable: true,
+				value: {...target, value: cleanedValue}
+			});
+			
+			props.onChange?.(event, {autocompleted: true});
+			return;
+		}
+
+		props.onChange?.(event);
+	}
 
 	function handleInput(event: React.FormEvent<HTMLInputElement>) {
 		const target = event.target as HTMLInputElement;
@@ -62,6 +91,7 @@ export const AutocompleteTextInput = React.forwardRef<
 		<>
 			<TextInput
 				list={datalistId}
+				onChange={handleChange}
 				onInput={handleInput}
 				ref={ref}
 				{...props}

--- a/src/components/control/text-input.tsx
+++ b/src/components/control/text-input.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import './text-input.css';
 
 export interface TextInputProps {
-	autoComplete?: string;
 	children: React.ReactNode;
 	list?: string;
 	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -27,7 +26,6 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 				<label>
 					<span className="text-input-label">{props.children}</span>
 					<input
-						autoComplete={props.autoComplete}
 						list={props.list}
 						onChange={props.onChange}
 						onInput={props.onInput}

--- a/src/components/control/text-input.tsx
+++ b/src/components/control/text-input.tsx
@@ -4,6 +4,7 @@ import './text-input.css';
 
 export interface TextInputProps {
 	children: React.ReactNode;
+	list?: string;
 	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 	onInput?: (event: React.FormEvent<HTMLInputElement>) => void;
 	orientation?: 'horizontal' | 'vertical';
@@ -25,6 +26,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 				<label>
 					<span className="text-input-label">{props.children}</span>
 					<input
+						list={props.list}
 						onChange={props.onChange}
 						onInput={props.onInput}
 						placeholder={props.placeholder}

--- a/src/components/control/text-input.tsx
+++ b/src/components/control/text-input.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import './text-input.css';
 
 export interface TextInputProps {
+	autoComplete?: string;
 	children: React.ReactNode;
 	list?: string;
 	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -26,6 +27,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 				<label>
 					<span className="text-input-label">{props.children}</span>
 					<input
+						autoComplete={props.autoComplete}
 						list={props.list}
 						onChange={props.onChange}
 						onInput={props.onInput}

--- a/src/components/control/text-input.tsx
+++ b/src/components/control/text-input.tsx
@@ -4,6 +4,7 @@ import './text-input.css';
 
 export interface TextInputProps {
 	children: React.ReactNode;
+	id?: string;
 	list?: string;
 	onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 	onInput?: (event: React.FormEvent<HTMLInputElement>) => void;
@@ -26,6 +27,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
 				<label>
 					<span className="text-input-label">{props.children}</span>
 					<input
+						id={props.id}
 						list={props.list}
 						onChange={props.onChange}
 						onInput={props.onInput}

--- a/src/components/tag/__tests__/tag-card-button.test.tsx
+++ b/src/components/tag/__tests__/tag-card-button.test.tsx
@@ -65,7 +65,6 @@ describe('<TagCardButton>', () => {
 				name: 'components.tagCardButton.tagNameLabel'
 			});
 
-			// Simulate selecting from datalist (value includes invisible separator)
 			fireEvent.input(input, {target: {value: 'existing-tag\u2063'}});
 
 			expect(onAdd).toHaveBeenCalledWith('existing-tag');
@@ -81,7 +80,6 @@ describe('<TagCardButton>', () => {
 			});
 			fireEvent.click(screen.getByRole('button', {name: 'common.tags'}));
 
-			// Simulate selecting empty/invalid tag from datalist
 			fireEvent.input(
 				screen.getByRole('combobox', {
 					name: 'components.tagCardButton.tagNameLabel'
@@ -106,7 +104,6 @@ describe('<TagCardButton>', () => {
 				})
 			);
 
-			// Simulate selecting duplicate tag from datalist
 			fireEvent.input(
 				screen.getByRole('combobox', {
 					name: 'components.tagCardButton.tagNameLabel'

--- a/src/components/tag/__tests__/tag-card-button.test.tsx
+++ b/src/components/tag/__tests__/tag-card-button.test.tsx
@@ -52,6 +52,71 @@ describe('<TagCardButton>', () => {
 			expect(onAdd.mock.calls).toEqual([['new-tag']]);
 		});
 
+		it('auto-adds tag when selected from datalist', () => {
+			const onAdd = jest.fn();
+
+			renderComponent({
+				allTags: ['existing-tag'],
+				onAdd
+			});
+			fireEvent.click(screen.getByRole('button', {name: 'common.tags'}));
+
+			const input = screen.getByRole('combobox', {
+				name: 'components.tagCardButton.tagNameLabel'
+			});
+
+			// Simulate selecting from datalist (value includes invisible separator)
+			fireEvent.input(input, {target: {value: 'existing-tag\u2063'}});
+
+			expect(onAdd).toHaveBeenCalledWith('existing-tag');
+			expect(input).toHaveValue('');
+		});
+
+		it('does not auto-add invalid tag from datalist', () => {
+			const onAdd = jest.fn();
+
+			renderComponent({
+				allTags: [''],
+				onAdd
+			});
+			fireEvent.click(screen.getByRole('button', {name: 'common.tags'}));
+
+			// Simulate selecting empty/invalid tag from datalist
+			fireEvent.input(
+				screen.getByRole('combobox', {
+					name: 'components.tagCardButton.tagNameLabel'
+				}),
+				{target: {value: '\u2063'}}
+			);
+
+			expect(onAdd).not.toHaveBeenCalled();
+		});
+
+		it('does not auto-add duplicate tag from datalist', () => {
+			const onAdd = jest.fn();
+
+			renderComponent({
+				allTags: ['duplicate'],
+				onAdd,
+				tags: ['duplicate']
+			});
+			fireEvent.click(
+				screen.getByRole('button', {
+					name: 'components.tagCardButton.tagsWithCount_plural'
+				})
+			);
+
+			// Simulate selecting duplicate tag from datalist
+			fireEvent.input(
+				screen.getByRole('combobox', {
+					name: 'components.tagCardButton.tagNameLabel'
+				}),
+				{target: {value: 'duplicate\u2063'}}
+			);
+
+			expect(onAdd).not.toHaveBeenCalled();
+		});
+
 		it("sets autocompletions to all tags that haven't already been added", () => {
 			renderComponent({
 				allTags: ['one', 'two', 'three'],

--- a/src/components/tag/__tests__/tag-card-button.test.tsx
+++ b/src/components/tag/__tests__/tag-card-button.test.tsx
@@ -41,7 +41,7 @@ describe('<TagCardButton>', () => {
 			renderComponent({onAdd});
 			fireEvent.click(screen.getByRole('button', {name: 'common.tags'}));
 			fireEvent.change(
-				screen.getByRole('textbox', {
+				screen.getByRole('combobox', {
 					name: 'components.tagCardButton.tagNameLabel'
 				}),
 				{target: {value: 'new-tag'}}
@@ -74,14 +74,14 @@ describe('<TagCardButton>', () => {
 			renderComponent();
 			fireEvent.click(screen.getByRole('button', {name: 'common.tags'}));
 			fireEvent.change(
-				screen.getByRole('textbox', {
+				screen.getByRole('combobox', {
 					name: 'components.tagCardButton.tagNameLabel'
 				}),
 				{target: {value: 'new-tag'}}
 			);
 			fireEvent.click(screen.getByRole('button', {name: 'common.add'}));
 			expect(
-				screen.getByRole('textbox', {
+				screen.getByRole('combobox', {
 					name: 'components.tagCardButton.tagNameLabel'
 				})
 			).toHaveValue('');
@@ -91,7 +91,7 @@ describe('<TagCardButton>', () => {
 			renderComponent();
 			fireEvent.click(screen.getByRole('button', {name: 'common.tags'}));
 			fireEvent.change(
-				screen.getByRole('textbox', {
+				screen.getByRole('combobox', {
 					name: 'components.tagCardButton.tagNameLabel'
 				}),
 				{target: {value: 'new-tag'}}
@@ -99,7 +99,7 @@ describe('<TagCardButton>', () => {
 			fireEvent.click(screen.getByRole('button', {name: 'common.tags'}));
 			fireEvent.click(screen.getByRole('button', {name: 'common.tags'}));
 			expect(
-				screen.getByRole('textbox', {
+				screen.getByRole('combobox', {
 					name: 'components.tagCardButton.tagNameLabel'
 				})
 			).toHaveValue('');
@@ -113,7 +113,7 @@ describe('<TagCardButton>', () => {
 				})
 			);
 			fireEvent.change(
-				screen.getByRole('textbox', {
+				screen.getByRole('combobox', {
 					name: 'components.tagCardButton.tagNameLabel'
 				}),
 				{target: {value: 'test'}}
@@ -129,7 +129,7 @@ describe('<TagCardButton>', () => {
 				})
 			);
 			fireEvent.change(
-				screen.getByRole('textbox', {
+				screen.getByRole('combobox', {
 					name: 'components.tagCardButton.tagNameLabel'
 				}),
 				{target: {value: 'test'}}
@@ -138,7 +138,7 @@ describe('<TagCardButton>', () => {
 				screen.getByRole('button', {name: 'common.add'})
 			).not.toBeDisabled();
 			fireEvent.change(
-				screen.getByRole('textbox', {
+				screen.getByRole('combobox', {
 					name: 'components.tagCardButton.tagNameLabel'
 				}),
 				{target: {value: ''}}

--- a/src/components/tag/__tests__/tag-card-button.test.tsx
+++ b/src/components/tag/__tests__/tag-card-button.test.tsx
@@ -10,6 +10,7 @@ describe('<TagCardButton>', () => {
 		return render(
 			<TagCardButton
 				allTags={[]}
+				id="test-tag-input"
 				onAdd={jest.fn()}
 				onChangeColor={jest.fn()}
 				onRemove={jest.fn()}
@@ -144,6 +145,15 @@ describe('<TagCardButton>', () => {
 				{target: {value: ''}}
 			);
 			expect(screen.getByRole('button', {name: 'common.add'})).toBeDisabled();
+		});
+
+		it('passes the id prop to the autocomplete input', () => {
+			renderComponent({id: 'custom-test-id'});
+			fireEvent.click(screen.getByRole('button', {name: 'common.tags'}));
+			const input = screen.getByRole('combobox', {
+				name: 'components.tagCardButton.tagNameLabel'
+			});
+			expect(input).toHaveAttribute('id', 'custom-test-id');
 		});
 
 		describe('The tag list it shows', () => {

--- a/src/components/tag/__tests__/tag-card-button.test.tsx
+++ b/src/components/tag/__tests__/tag-card-button.test.tsx
@@ -52,68 +52,6 @@ describe('<TagCardButton>', () => {
 			expect(onAdd.mock.calls).toEqual([['new-tag']]);
 		});
 
-		it('auto-adds tag when selected from datalist', () => {
-			const onAdd = jest.fn();
-
-			renderComponent({
-				allTags: ['existing-tag'],
-				onAdd
-			});
-			fireEvent.click(screen.getByRole('button', {name: 'common.tags'}));
-
-			const input = screen.getByRole('combobox', {
-				name: 'components.tagCardButton.tagNameLabel'
-			});
-
-			fireEvent.input(input, {target: {value: 'existing-tag\u2063'}});
-
-			expect(onAdd).toHaveBeenCalledWith('existing-tag');
-			expect(input).toHaveValue('');
-		});
-
-		it('does not auto-add invalid tag from datalist', () => {
-			const onAdd = jest.fn();
-
-			renderComponent({
-				allTags: [''],
-				onAdd
-			});
-			fireEvent.click(screen.getByRole('button', {name: 'common.tags'}));
-
-			fireEvent.input(
-				screen.getByRole('combobox', {
-					name: 'components.tagCardButton.tagNameLabel'
-				}),
-				{target: {value: '\u2063'}}
-			);
-
-			expect(onAdd).not.toHaveBeenCalled();
-		});
-
-		it('does not auto-add duplicate tag from datalist', () => {
-			const onAdd = jest.fn();
-
-			renderComponent({
-				allTags: ['duplicate'],
-				onAdd,
-				tags: ['duplicate']
-			});
-			fireEvent.click(
-				screen.getByRole('button', {
-					name: 'components.tagCardButton.tagsWithCount_plural'
-				})
-			);
-
-			fireEvent.input(
-				screen.getByRole('combobox', {
-					name: 'components.tagCardButton.tagNameLabel'
-				}),
-				{target: {value: 'duplicate\u2063'}}
-			);
-
-			expect(onAdd).not.toHaveBeenCalled();
-		});
-
 		it("sets autocompletions to all tags that haven't already been added", () => {
 			renderComponent({
 				allTags: ['one', 'two', 'three'],

--- a/src/components/tag/tag-card-button.tsx
+++ b/src/components/tag/tag-card-button.tsx
@@ -3,7 +3,10 @@ import {useTranslation} from 'react-i18next';
 import {CardButton} from '../control/card-button';
 import {IconPlus, IconTag} from '@tabler/icons';
 import {CardContent} from '../container/card';
-import {AutocompleteTextInput} from '../control/autocomplete-text-input';
+import {
+	AutocompleteTextInput,
+	DATALIST_SELECTION_MARKER
+} from '../control/autocomplete-text-input';
 import {IconButton} from '../control/icon-button';
 import {Color} from '../../util/color';
 import {TagButton} from './tag-button';
@@ -26,7 +29,6 @@ export const TagCardButton: React.FC<TagCardButtonProps> = props => {
 		props;
 	const [newTagName, setNewTagName] = React.useState('');
 	const [open, setOpen] = React.useState(false);
-	const isSelectingRef = React.useRef(false);
 	const {t} = useTranslation();
 	const tagCompletions = React.useMemo(
 		() => allTags.filter(tag => !tags.includes(tag)),
@@ -54,23 +56,16 @@ export const TagCardButton: React.FC<TagCardButtonProps> = props => {
 	}
 
 	function handleNewTagNameChange(event: React.ChangeEvent<HTMLInputElement>) {
-		if (isSelectingRef.current) {
-			isSelectingRef.current = false;
+		let value = event.target.value;
+
+		if (value.endsWith(DATALIST_SELECTION_MARKER)) {
+			value = value.slice(0, -1).replaceAll(' ', '-');
+			onAdd(value);
+			setNewTagName('');
 			return;
 		}
-		setNewTagName(event.target.value.replaceAll(' ', '-'));
-	}
 
-	function handleSelect(value: string) {
-		const normalizedValue = value.replaceAll(' ', '-');
-		const isValid = isValidTagName(normalizedValue);
-		const canAddTag = isValid && !tags.includes(normalizedValue);
-
-		if (canAddTag && normalizedValue.trim() !== '') {
-			isSelectingRef.current = true;
-			onAdd(normalizedValue);
-			setNewTagName('');
-		}
+		setNewTagName(value.replaceAll(' ', '-'));
 	}
 
 	function handleSubmit(event: React.FormEvent) {
@@ -106,7 +101,6 @@ export const TagCardButton: React.FC<TagCardButtonProps> = props => {
 							completions={tagCompletions}
 							id={id}
 							onChange={handleNewTagNameChange}
-							onSelect={handleSelect}
 							value={newTagName}
 						>
 							{t('components.tagCardButton.tagNameLabel')}

--- a/src/components/tag/tag-card-button.tsx
+++ b/src/components/tag/tag-card-button.tsx
@@ -13,6 +13,7 @@ import './tag-card-button.css';
 export interface TagCardButtonProps {
 	disabled?: boolean;
 	allTags: string[];
+	id: string;
 	onAdd: (value: string) => void;
 	onChangeColor: (value: string, color: Color) => void;
 	onRemove: (value: string) => void;
@@ -21,7 +22,7 @@ export interface TagCardButtonProps {
 }
 
 export const TagCardButton: React.FC<TagCardButtonProps> = props => {
-	const {allTags, disabled, onAdd, onChangeColor, onRemove, tagColors, tags} =
+	const {allTags, disabled, id, onAdd, onChangeColor, onRemove, tagColors, tags} =
 		props;
 	const [newTagName, setNewTagName] = React.useState('');
 	const [open, setOpen] = React.useState(false);
@@ -86,7 +87,7 @@ export const TagCardButton: React.FC<TagCardButtonProps> = props => {
 					<form onSubmit={handleSubmit}>
 						<AutocompleteTextInput
 							completions={tagCompletions}
-							id="tag-input"
+							id={id}
 							onChange={handleNewTagNameChange}
 							value={newTagName}
 						>

--- a/src/components/tag/tag-card-button.tsx
+++ b/src/components/tag/tag-card-button.tsx
@@ -86,6 +86,7 @@ export const TagCardButton: React.FC<TagCardButtonProps> = props => {
 					<form onSubmit={handleSubmit}>
 						<AutocompleteTextInput
 							completions={tagCompletions}
+							id="tag-input"
 							onChange={handleNewTagNameChange}
 							value={newTagName}
 						>

--- a/src/components/tag/tag-card-button.tsx
+++ b/src/components/tag/tag-card-button.tsx
@@ -26,10 +26,11 @@ export const TagCardButton: React.FC<TagCardButtonProps> = props => {
 		props;
 	const [newTagName, setNewTagName] = React.useState('');
 	const [open, setOpen] = React.useState(false);
+	const isSelectingRef = React.useRef(false);
 	const {t} = useTranslation();
 	const tagCompletions = React.useMemo(
 		() => allTags.filter(tag => !tags.includes(tag)),
-		[allTags]
+		[allTags, tags]
 	);
 	const label =
 		tags.length === 0
@@ -53,7 +54,23 @@ export const TagCardButton: React.FC<TagCardButtonProps> = props => {
 	}
 
 	function handleNewTagNameChange(event: React.ChangeEvent<HTMLInputElement>) {
-		setNewTagName(event.target.value.replace(/\s/g, '-'));
+		if (isSelectingRef.current) {
+			isSelectingRef.current = false;
+			return;
+		}
+		setNewTagName(event.target.value.replaceAll(' ', '-'));
+	}
+
+	function handleSelect(value: string) {
+		const normalizedValue = value.replaceAll(' ', '-');
+		const isValid = isValidTagName(normalizedValue);
+		const canAddTag = isValid && !tags.includes(normalizedValue);
+
+		if (canAddTag && normalizedValue.trim() !== '') {
+			isSelectingRef.current = true;
+			onAdd(normalizedValue);
+			setNewTagName('');
+		}
 	}
 
 	function handleSubmit(event: React.FormEvent) {
@@ -89,6 +106,7 @@ export const TagCardButton: React.FC<TagCardButtonProps> = props => {
 							completions={tagCompletions}
 							id={id}
 							onChange={handleNewTagNameChange}
+							onSelect={handleSelect}
 							value={newTagName}
 						>
 							{t('components.tagCardButton.tagNameLabel')}

--- a/src/components/tag/tag-card-button.tsx
+++ b/src/components/tag/tag-card-button.tsx
@@ -57,7 +57,7 @@ export const TagCardButton: React.FC<TagCardButtonProps> = props => {
 		event: React.ChangeEvent<HTMLInputElement>,
 		metadata?: AutocompleteMetadata
 	) {
-		let value = event.target.value;
+		const value = event.target.value.replaceAll(' ', '-');
 
 		if (metadata?.autocompleted) {
 			value = value.replaceAll(' ', '-');

--- a/src/components/tag/tag-card-button.tsx
+++ b/src/components/tag/tag-card-button.tsx
@@ -3,10 +3,8 @@ import {useTranslation} from 'react-i18next';
 import {CardButton} from '../control/card-button';
 import {IconPlus, IconTag} from '@tabler/icons';
 import {CardContent} from '../container/card';
-import {
-	AutocompleteTextInput,
-	DATALIST_SELECTION_MARKER
-} from '../control/autocomplete-text-input';
+import {AutocompleteTextInput} from '../control/autocomplete-text-input';
+import type {AutocompleteMetadata} from '../control/autocomplete-text-input';
 import {IconButton} from '../control/icon-button';
 import {Color} from '../../util/color';
 import {TagButton} from './tag-button';
@@ -55,11 +53,14 @@ export const TagCardButton: React.FC<TagCardButtonProps> = props => {
 		}
 	}
 
-	function handleNewTagNameChange(event: React.ChangeEvent<HTMLInputElement>) {
+	function handleNewTagNameChange(
+		event: React.ChangeEvent<HTMLInputElement>,
+		metadata?: AutocompleteMetadata
+	) {
 		let value = event.target.value;
 
-		if (value.endsWith(DATALIST_SELECTION_MARKER)) {
-			value = value.slice(0, -1).replaceAll(' ', '-');
+		if (metadata?.autocompleted) {
+			value = value.replaceAll(' ', '-');
 			onAdd(value);
 			setNewTagName('');
 			return;

--- a/src/components/tag/tag-card-button.tsx
+++ b/src/components/tag/tag-card-button.tsx
@@ -60,13 +60,12 @@ export const TagCardButton: React.FC<TagCardButtonProps> = props => {
 		const value = event.target.value.replaceAll(' ', '-');
 
 		if (metadata?.autocompleted) {
-			value = value.replaceAll(' ', '-');
 			onAdd(value);
 			setNewTagName('');
 			return;
 		}
 
-		setNewTagName(value.replaceAll(' ', '-'));
+		setNewTagName(value);
 	}
 
 	function handleSubmit(event: React.FormEvent) {

--- a/src/dialogs/passage-edit/passage-toolbar.tsx
+++ b/src/dialogs/passage-edit/passage-toolbar.tsx
@@ -70,6 +70,7 @@ export const PassageToolbar: React.FC<PassageToolbarProps> = props => {
 			)}
 			<TagCardButton
 				allTags={passageTags}
+				id={`passage-tag-input-${passage.id}`}
 				onAdd={handleAddTag}
 				onChangeColor={handleChangeTagColor}
 				onRemove={handleRemoveTag}

--- a/src/routes/story-list/toolbar/story/tag-story-button.tsx
+++ b/src/routes/story-list/toolbar/story/tag-story-button.tsx
@@ -65,6 +65,7 @@ export const TagStoryButton: React.FC<TagStoryButtonProps> = props => {
 		<TagCardButton
 			allTags={allStoryTags}
 			disabled={!story}
+			id={`story-tag-input-${story?.id ?? 'none'}`}
 			onAdd={handleAddTag}
 			onChangeColor={handleChangeTagColor}
 			onRemove={handleRemoveTag}


### PR DESCRIPTION
# Description

This PR adds a case-insensitive autocomplete for tags.

Tested by running:

- `npm run test`
- `npm run build:web`
- `npm run lint`
- `npm run start`

Screenshots are of various behaviours in the web vite build:

**Arrow Down to navigate options**:

<img width="1287" height="627" alt="Screen Shot 2025-11-14 at 3 00 58 AM" src="https://github.com/user-attachments/assets/0deaa42d-8058-494b-91e1-0fdf0e44745a" />

**Search "test-1" to filter out "example" (notice case insensitive results)**:

<img width="1288" height="575" alt="Screen Shot 2025-11-14 at 3 01 21 AM" src="https://github.com/user-attachments/assets/9c769c64-d44e-46fa-87a9-6cc97bb827b7" />

**Search "example" to filter out "test-\*"**:

<img width="1291" height="572" alt="Screen Shot 2025-11-14 at 3 01 38 AM" src="https://github.com/user-attachments/assets/ea691d9c-6e84-4d7e-9c00-2a13d12a302b" />

No added dependencies and close to simple `dataset` design mentioned in https://github.com/klembot/twinejs/issues/1640#issuecomment-3517363071''

Tests had to be updated elsewhere since an `input` with a list referencing a `datalist` can have some browsers identify that as a `combobox`, which was what was happening in tests thus causing failures which had to be addressed.

# Issues Fixed

Fixes #1640

# Credit

Please put an X in *one* of the squares below only.

[X] I would like to be credited in the application as: Edgar San Martin, Jr.

# Presubmission Checklist

Put an X in the squares below to indicate you've done each step.

[X] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[X] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[X] I have read and agree to abide by this project's Code of Conduct.