### PR TITLE
Set start passage correctly on duplicated story

### DIFF
--- a/src/store/stories/action-creators/__tests__/duplicate-story.test.ts
+++ b/src/store/stories/action-creators/__tests__/duplicate-story.test.ts
@@ -22,7 +22,9 @@ describe('duplicateStory action creator', () => {
 						id: expect.any(String),
 						story: expect.any(String)
 					})
-				)
+				),
+				// Tested below.
+				startPassage: expect.any(String)
 			})
 		}));
 
@@ -63,5 +65,23 @@ describe('duplicateStory action creator', () => {
 		for (let i = 0; i < story.passages.length; i++) {
 			expect(result.props.passages![i].id).not.toBe(story.passages[i].id);
 		}
+	});
+
+	it("sets the duplicate's start passage correctly", () => {
+		story = fakeStory(3);
+		story.startPassage = story.passages[2].id;
+
+		// It's OK if 0 or 1 have the same name, but we need to be sure that the
+		// third passage has a unique name.
+
+		expect(story.passages[2].name).not.toEqual(story.passages[0].name);
+		expect(story.passages[2].name).not.toEqual(story.passages[1].name);
+
+		const startPassageName = story.passages[2].name;
+		const result = duplicateStory(story, [story]);
+		const duplicatedStartPassage = result.props.passages?.find(({name}) => name === startPassageName);
+
+		expect(duplicatedStartPassage).not.toBeUndefined();
+		expect(result.props.startPassage).toBe(duplicatedStartPassage!.id);
 	});
 });

--- a/src/store/stories/action-creators/duplicate-story.ts
+++ b/src/store/stories/action-creators/duplicate-story.ts
@@ -10,6 +10,14 @@ export function duplicateStory(
 	stories: Story[]
 ): CreateStoryAction {
 	const id = uuid();
+	const duplicatedPassages = story.passages.map(passage => ({
+		...passage,
+		id: uuid(),
+		story: id
+	}));
+	const originalStartPassage = story.passages.find(
+		({id}) => id === story.startPassage
+	);
 
 	return {
 		type: 'createStory',
@@ -21,11 +29,12 @@ export function duplicateStory(
 				story.name,
 				stories.map(story => story.name)
 			),
-			passages: story.passages.map(passage => ({
-				...passage,
-				id: uuid(),
-				story: id
-			}))
+			passages: duplicatedPassages,
+			startPassage: originalStartPassage
+				? duplicatedPassages.find(
+						({name}) => name === originalStartPassage.name
+					)?.id
+				: undefined
 		}
 	};
 }


### PR DESCRIPTION
Resolves #1653; core issue was that the duplicated story had a startPassage that pointed to a nonexistent passage.