### PR TITLE
Truncate long passage titles in editor

### DIFF
--- a/src/components/container/dialog-card/dialog-card.css
+++ b/src/components/container/dialog-card/dialog-card.css
@@ -18,7 +18,8 @@
 
 .dialog-card h2 {
 	align-items: center;
-	display: flex;
+	display: grid;
+	grid-template-columns: 1fr auto;
 }
 
 .dialog-card h2 .dialog-card-header {
@@ -29,10 +30,7 @@
 	gap: var(--control-inner-padding);
 	min-width: 0;
 	padding-left: var(--grid-size);
-}
-
-.dialog-card h2 .dialog-card-header-controls {
-	flex-shrink: 1;
+	white-space: nowrap;
 }
 
 .dialog-card h2 .dialog-card-header .icon-button {

--- a/src/dialogs/passage-edit/passage-edit-stack.css
+++ b/src/dialogs/passage-edit/passage-edit-stack.css
@@ -13,8 +13,15 @@
 }
 
 .passage-edit-stack .dialog-card-header .tag-grid {
+	flex-shrink: 0;
 	height: 16px;
 	width: 16px;
+}
+
+.passage-edit-stack .dialog-card-header .visible-whitespace {
+	flex-shrink: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .passage-edit-stack .dialog-card-header .visible-whitespace svg {

--- a/src/store/prefs/prefs.types.ts
+++ b/src/store/prefs/prefs.types.ts
@@ -19,7 +19,7 @@ export type PrefsAction =
 
 export interface PrefsState {
 	/**
-	 *
+	 * What theme to use for the application.
 	 */
 	appTheme: 'dark' | 'light' | 'system';
 	/**


### PR DESCRIPTION
Avoids overflowing the passage editor header when a passage name is long.