### PR TITLE
Add in place passage rename

### DIFF
--- a/src/components/passage/__tests__/inline-passage-title.test.tsx
+++ b/src/components/passage/__tests__/inline-passage-title.test.tsx
@@ -1,0 +1,281 @@
+import {act, fireEvent, render, screen} from '@testing-library/react';
+import {axe} from 'jest-axe';
+import * as React from 'react';
+import {
+	FakeStateProvider,
+	FakeStateProviderProps,
+	fakeStory,
+	StoryInspector
+} from '../../../test-util';
+import {
+	InlinePassageTitle,
+	InlinePassageTitleProps
+} from '../inline-passage-title';
+import {useStoriesContext} from '../../../store/stories';
+
+const TestInlinePassageTitle: React.FC<
+	Partial<InlinePassageTitleProps> & {storyPassageCount?: number}
+> = ({storyPassageCount, ...overrides}) => {
+	const {stories} = useStoriesContext();
+	const story = stories[0];
+	const passage = story.passages[0];
+
+	return (
+		<InlinePassageTitle
+			passage={passage}
+			story={story}
+			{...overrides}
+		/>
+	);
+};
+
+function renderComponent(
+	props?: Partial<InlinePassageTitleProps>,
+	context?: FakeStateProviderProps
+) {
+	return render(
+		<FakeStateProvider {...context}>
+			<TestInlinePassageTitle {...props} />
+			<StoryInspector />
+		</FakeStateProvider>
+	);
+}
+
+describe('<InlinePassageTitle>', () => {
+	describe('when not editing', () => {
+		it('displays the passage name', () => {
+			const story = fakeStory(1);
+
+			renderComponent({}, {stories: [story]});
+			expect(screen.getByText(story.passages[0].name.trim())).toBeInTheDocument();
+		});
+
+		it('shows a rename tooltip when not disabled', () => {
+			const story = fakeStory(1);
+
+			renderComponent({}, {stories: [story]});
+			expect(
+				document.querySelector('[title="common.rename"]')
+			).toBeInTheDocument();
+		});
+
+		it('does not show a rename tooltip when disabled', () => {
+			const story = fakeStory(1);
+
+			renderComponent({disabled: true}, {stories: [story]});
+			expect(
+				document.querySelector('[title="common.rename"]')
+			).not.toBeInTheDocument();
+		});
+
+		it('enters edit mode on double-click', () => {
+			const story = fakeStory(1);
+
+			renderComponent({}, {stories: [story]});
+			fireEvent.doubleClick(
+				screen.getByText(story.passages[0].name.trim())
+			);
+			expect(
+				screen.getByRole('textbox', {name: 'common.rename'})
+			).toBeInTheDocument();
+		});
+
+		it('does not enter edit mode on double-click when disabled', () => {
+			const story = fakeStory(1);
+
+			renderComponent({disabled: true}, {stories: [story]});
+			fireEvent.doubleClick(
+				screen.getByText(story.passages[0].name.trim())
+			);
+			expect(
+				screen.queryByRole('textbox', {name: 'common.rename'})
+			).not.toBeInTheDocument();
+		});
+	});
+
+	describe('when editing', () => {
+		function enterEditMode(story: ReturnType<typeof fakeStory>) {
+			fireEvent.doubleClick(
+				screen.getByText(story.passages[0].name.trim())
+			);
+		}
+
+		it('pre-fills the input with the current passage name', () => {
+			const story = fakeStory(1);
+
+			renderComponent({}, {stories: [story]});
+			enterEditMode(story);
+			expect(
+				screen.getByRole('textbox', {name: 'common.rename'})
+			).toHaveValue(story.passages[0].name);
+		});
+
+		it('renames the passage on Enter', () => {
+			const story = fakeStory(1);
+
+			renderComponent({}, {stories: [story]});
+			enterEditMode(story);
+			fireEvent.change(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{target: {value: 'new-name'}}
+			);
+			fireEvent.keyDown(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{key: 'Enter'}
+			);
+			expect(
+				screen.getByTestId(`passage-${story.passages[0].id}`).dataset.name
+			).toBe('new-name');
+		});
+
+		it('does not rename if the value is unchanged on Enter', () => {
+			const story = fakeStory(1);
+			const originalName = story.passages[0].name;
+
+			renderComponent({}, {stories: [story]});
+			enterEditMode(story);
+			fireEvent.keyDown(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{key: 'Enter'}
+			);
+			// Should exit edit mode without dispatching
+			expect(
+				screen.getByTestId(`passage-${story.passages[0].id}`).dataset.name
+			).toBe(originalName);
+		});
+
+		it('cancels editing on Escape', () => {
+			const story = fakeStory(1);
+			const originalName = story.passages[0].name;
+
+			renderComponent({}, {stories: [story]});
+			enterEditMode(story);
+			fireEvent.change(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{target: {value: 'changed-name'}}
+			);
+			fireEvent.keyDown(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{key: 'Escape'}
+			);
+			// Should exit edit mode without renaming
+			expect(
+				screen.queryByRole('textbox', {name: 'common.rename'})
+			).not.toBeInTheDocument();
+			expect(
+				screen.getByTestId(`passage-${story.passages[0].id}`).dataset.name
+			).toBe(originalName);
+		});
+
+		it('submits on blur', () => {
+			const story = fakeStory(1);
+
+			renderComponent({}, {stories: [story]});
+			enterEditMode(story);
+			fireEvent.change(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{target: {value: 'blur-name'}}
+			);
+			fireEvent.blur(
+				screen.getByRole('textbox', {name: 'common.rename'})
+			);
+			expect(
+				screen.getByTestId(`passage-${story.passages[0].id}`).dataset.name
+			).toBe('blur-name');
+		});
+
+		it('shows a tooltip error for empty names', () => {
+			const story = fakeStory(1);
+
+			renderComponent({}, {stories: [story]});
+			enterEditMode(story);
+			fireEvent.change(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{target: {value: ''}}
+			);
+			fireEvent.keyDown(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{key: 'Enter'}
+			);
+			expect(screen.getByRole('alert')).toHaveTextContent(
+				'components.renamePassageButton.emptyName'
+			);
+		});
+
+		it('shows a tooltip error for duplicate names', () => {
+			const story = fakeStory(2);
+
+			renderComponent({}, {stories: [story]});
+			enterEditMode(story);
+			fireEvent.change(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{target: {value: story.passages[1].name}}
+			);
+			fireEvent.keyDown(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{key: 'Enter'}
+			);
+			expect(screen.getByRole('alert')).toHaveTextContent(
+				'components.renamePassageButton.nameAlreadyUsed'
+			);
+		});
+
+		it('clears the error when the user types', () => {
+			const story = fakeStory(1);
+
+			renderComponent({}, {stories: [story]});
+			enterEditMode(story);
+			fireEvent.change(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{target: {value: ''}}
+			);
+			fireEvent.keyDown(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{key: 'Enter'}
+			);
+			expect(screen.getByRole('alert')).toBeInTheDocument();
+			fireEvent.change(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{target: {value: 'a'}}
+			);
+			expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+		});
+
+		it('stays in edit mode when validation fails', () => {
+			const story = fakeStory(1);
+
+			renderComponent({}, {stories: [story]});
+			enterEditMode(story);
+			fireEvent.change(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{target: {value: ''}}
+			);
+			fireEvent.keyDown(
+				screen.getByRole('textbox', {name: 'common.rename'}),
+				{key: 'Enter'}
+			);
+			// Should still be in edit mode
+			expect(
+				screen.getByRole('textbox', {name: 'common.rename'})
+			).toBeInTheDocument();
+		});
+	});
+
+	it('is accessible when not editing', async () => {
+		const {container} = renderComponent();
+
+		expect(await axe(container)).toHaveNoViolations();
+	});
+
+	it('is accessible when editing', async () => {
+		const story = fakeStory(1);
+
+		const {container} = renderComponent({}, {stories: [story]});
+
+		fireEvent.doubleClick(
+			screen.getByText(story.passages[0].name.trim())
+		);
+		await act(() => Promise.resolve());
+		expect(await axe(container)).toHaveNoViolations();
+	});
+});

--- a/src/components/passage/inline-passage-title.css
+++ b/src/components/passage/inline-passage-title.css
@@ -1,0 +1,44 @@
+.inline-passage-title-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+.inline-passage-title-wrapper input.inline-passage-title {
+	background: var(--white);
+	border: 1px solid var(--blue);
+	border-radius: 2px;
+	font-size: 1rem;
+	font-weight: bold;
+	outline: none;
+	padding: 2px 4px;
+	width: 100%;
+}
+
+.inline-passage-title-wrapper input.has-error.inline-passage-title {
+	border-color: var(--red);
+}
+
+.inline-passage-title-wrapper .inline-passage-title-error {
+	background-color: var(--red);
+	border-radius: var(--corner-round);
+	color: black;
+	font-size: 13px;
+	font-weight: normal;
+	padding: var(--grid-size);
+	position: absolute;
+	top: calc(100% + 8px);
+	left: 0;
+	white-space: nowrap;
+	z-index: 3000;
+    user-select: none;
+}
+
+.inline-passage-title-wrapper .inline-passage-title-error-arrow {
+	background: var(--red);
+	width: 10px;
+	height: 10px;
+	position: absolute;
+	top: -10px;
+	left: 12px;
+	clip-path: polygon(50% 33%, 100% 100%, 0 100%);
+}

--- a/src/components/passage/inline-passage-title.tsx
+++ b/src/components/passage/inline-passage-title.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import {useTranslation} from 'react-i18next';
+import {VisibleWhitespace} from '../visible-whitespace';
+import {Passage, Story, updatePassage} from '../../store/stories';
+import './inline-passage-title.css';
+import classNames from 'classnames';
+import { useUndoableStoriesContext } from '../../store/undoable-stories';
+
+export interface InlinePassageTitleProps {
+	disabled?: boolean;
+	passage: Passage;
+	story: Story;
+}
+
+export const InlinePassageTitle: React.FC<InlinePassageTitleProps> = props => {
+	const {disabled, passage, story} = props;
+	const {t} = useTranslation();
+    const title = passage.name;
+	const [editing, setEditing] = React.useState(false);
+	const [editValue, setEditValue] = React.useState(title);
+	const [error, setError] = React.useState<string>();
+	const inputRef = React.useRef<HTMLInputElement>(null);
+    const {dispatch} = useUndoableStoriesContext();
+
+	React.useEffect(() => {
+		if (editing && inputRef.current) {
+			inputRef.current.focus();
+			inputRef.current.select();
+		}
+	}, [editing]);
+
+	// Keep editValue in sync if the passage name changes externally while not editing.
+	React.useEffect(() => {
+		if (!editing) {
+			setEditValue(title);
+		}
+	}, [editing, title]);
+
+	function validate(name: string): string | undefined {
+		if (name.trim() === '') {
+			return t('components.renamePassageButton.emptyName');
+		}
+
+		if (
+			story.passages.some(p => p.id !== passage.id && p.name === name)
+		) {
+			return t('components.renamePassageButton.nameAlreadyUsed');
+		}
+
+		return undefined;
+	}
+
+	function handleDoubleClick(event: React.MouseEvent) {
+		if (disabled) {
+			return;
+		}
+
+		event.stopPropagation();
+		setEditing(true);
+		setEditValue(title);
+		setError(undefined);
+	}
+
+	function handleSubmit() {
+		const validationError = validate(editValue);
+
+		if (validationError) {
+			setError(validationError);
+			return;
+		}
+
+		setEditing(false);
+		setError(undefined);
+
+		if (editValue !== title) {
+            // Don't create newly linked passages here because the update action will
+            // try to recreate the passage as it's been renamed--it sees new links in
+            // existing passages, updates them, but does not see that the passage name
+            // has been updated since that hasn't happened yet.
+
+            dispatch(updatePassage(story, passage, {name: editValue}, {dontUpdateOthers: true}));
+		}
+	}
+
+	function handleCancel() {
+		setEditing(false);
+		setEditValue(title);
+		setError(undefined);
+	}
+
+	function handleKeyDown(event: React.KeyboardEvent) {
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			event.stopPropagation();
+			handleSubmit();
+		} else if (event.key === 'Escape') {
+			event.preventDefault();
+			event.stopPropagation();
+			handleCancel();
+		}
+	}
+
+	if (editing) {
+		return (
+			<span className="inline-passage-title-wrapper">
+				<input
+					ref={inputRef}
+					aria-label={t('common.rename')}
+					className={classNames(
+						'inline-passage-title',
+						{'has-error': error}
+					)}
+					onBlur={handleSubmit}
+					onChange={event => {
+						setEditValue(event.target.value);
+						setError(undefined);
+					}}
+					onKeyDown={handleKeyDown}
+					value={editValue}
+				/>
+				{error && (
+					<span className="inline-passage-title-error" role="alert">
+						<span className="inline-passage-title-error-arrow" />
+						{error}
+					</span>
+				)}
+			</span>
+		);
+	}
+
+	return (
+		<>
+			<VisibleWhitespace
+                value={title}
+                title={disabled ? undefined : t('common.rename')}
+                onDoubleClick={handleDoubleClick}
+            />
+		</>
+	);
+};

--- a/src/components/visible-whitespace/visible-whitespace.tsx
+++ b/src/components/visible-whitespace/visible-whitespace.tsx
@@ -3,13 +3,15 @@ import * as React from 'react';
 
 export interface VisibleWhitespaceProps {
 	value: string;
+	title?: string;
+	onDoubleClick?: React.MouseEventHandler;
 }
 
 /**
  * Makes leading and trailing whitespace in a string visible.
  */
 export const VisibleWhitespace: React.FC<VisibleWhitespaceProps> = ({
-	value
+	value, onDoubleClick, title
 }) => {
 	const leadingMatch = /^\s*/.exec(value);
 	const leaders = leadingMatch ? leadingMatch[0].length : 0;
@@ -17,7 +19,11 @@ export const VisibleWhitespace: React.FC<VisibleWhitespaceProps> = ({
 	const trailers = trailingMatch ? trailingMatch[0].length : 0;
 
 	return (
-		<span className="visible-whitespace">
+		<span
+			className="visible-whitespace"
+			onDoubleClick={onDoubleClick}
+			title={title}
+		>
 			{[...Array(leaders)].map((_, index) => (
 				<IconSpace key={index} />
 			))}

--- a/src/dialogs/passage-edit/__tests__/passage-toolbar.test.tsx
+++ b/src/dialogs/passage-edit/__tests__/passage-toolbar.test.tsx
@@ -12,7 +12,6 @@ import {PassageToolbar} from '../passage-toolbar';
 import {usePrefsContext} from '../../../store/prefs';
 
 jest.mock('../../../components/control/menu-button');
-jest.mock('../../../components/passage/rename-passage-button');
 jest.mock('../../../components/tag/tag-card-button');
 
 const TestPassageToolbar: React.FC = () => {
@@ -99,18 +98,6 @@ describe('<PassageToolbar>', () => {
 		).toBe(
 			JSON.stringify({...tagColors, 'mock-tag-name': 'mock-changed-color'})
 		);
-	});
-
-	it('renames the passage if the user uses the rename button', async () => {
-		const story = fakeStory(1);
-
-		await renderComponent({stories: [story]});
-		fireEvent.click(
-			screen.getByText(`mock-rename-passage-button-${story.passages[0].id}`)
-		);
-		expect(
-			screen.getByTestId(`passage-${story.passages[0].id}`).dataset.name
-		).toBe('mock-new-passage-name');
 	});
 
 	it('displays a button to test the story from this passage', () => {

--- a/src/dialogs/passage-edit/passage-edit-stack.tsx
+++ b/src/dialogs/passage-edit/passage-edit-stack.tsx
@@ -5,6 +5,7 @@ import {
 	DialogCard
 } from '../../components/container/dialog-card';
 import {DialogStack} from '../../components/container/dialog-card/dialog-stack';
+import {InlinePassageTitle} from '../../components/passage/inline-passage-title';
 import {TagGrid} from '../../components/tag';
 import {VisibleWhitespace} from '../../components/visible-whitespace';
 import {
@@ -32,7 +33,8 @@ const InnerPassageEditStack: React.FC<PassageEditStackProps> = props => {
 		props;
 	const {dispatch} = useDialogsContext();
 	const {stories} = useStoriesContext();
-	const storyTagColors = storyWithId(stories, storyId).tagColors;
+	const story = storyWithId(stories, storyId);
+	const storyTagColors = story.tagColors;
 	const passageInfo = passageIds.map(passageId => {
 		const passage = passageWithId(stories, storyId, passageId);
 
@@ -98,7 +100,9 @@ const InnerPassageEditStack: React.FC<PassageEditStackProps> = props => {
 						);
 					}
 
-					return (
+						const passage = passageWithId(stories, storyId, passageId);
+
+						return (
 						<DialogCard
 							{...managementProps}
 							headerDisplayLabel={
@@ -107,7 +111,11 @@ const InnerPassageEditStack: React.FC<PassageEditStackProps> = props => {
 										tags={passageInfo[index].tags}
 										tagColors={storyTagColors}
 									/>
-									<VisibleWhitespace value={passageInfo[index].name} />
+									<InlinePassageTitle
+										disabled={managementProps.collapsed}
+										passage={passage}
+										story={story}
+									/>
 								</>
 							}
 							headerLabel={passageInfo[index].name}

--- a/src/dialogs/passage-edit/passage-toolbar.tsx
+++ b/src/dialogs/passage-edit/passage-toolbar.tsx
@@ -5,7 +5,6 @@ import {useTranslation} from 'react-i18next';
 import {UndoRedoButtons} from '../../components/codemirror';
 import {ButtonBar} from '../../components/container/button-bar';
 import {MenuButton} from '../../components/control/menu-button';
-import {RenamePassageButton} from '../../components/passage/rename-passage-button';
 import {TestPassageButton} from '../../routes/story-edit/toolbar/passage/test-passage-button';
 import {
 	addPassageTag,
@@ -46,14 +45,6 @@ export const PassageToolbar: React.FC<PassageToolbarProps> = props => {
 		dispatch(removePassageTag(story, passage, name), t('undoChange.removeTag'));
 	}
 
-	function handleRename(name: string) {
-		// Don't create newly linked passages here because the update action will
-		// try to recreate the passage as it's been renamed--it sees new links in
-		// existing passages, updates them, but does not see that the passage name
-		// has been updated since that hasn't happened yet.
-
-		dispatch(updatePassage(story, passage, {name}, {dontUpdateOthers: true}));
-	}
 
 	function handleSetSize({height, width}: {height: number; width: number}) {
 		dispatch(updatePassage(story, passage, {height, width}));
@@ -107,12 +98,6 @@ export const PassageToolbar: React.FC<PassageToolbarProps> = props => {
 					}
 				]}
 				label={t('dialogs.passageEdit.size')}
-			/>
-			<RenamePassageButton
-				disabled={disabled}
-				onRename={handleRename}
-				passage={passage}
-				story={story}
 			/>
 			<TestPassageButton passage={passage} story={story} />
 		</ButtonBar>


### PR DESCRIPTION
# Description

This PR remove the rename button in the passage edit toolbar, and replace it by a inline rename.

This solution has NOT been validated yet, this is why I used a draft pull request.

# Issues Fixed

Fix this issue: #1013

# Credit

Please put an X in *one* of the squares below only.

[ ] I would like to be credited in the application as: ______ \
[ ] I would not like my name to appear in the application credits.
[x] I don't care about being credited, but if you want to please use *Potiron*

# Presubmission Checklist

[ ] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[x] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[x] I have read and agree to abide by this project's Code of Conduct.