### PR TITLE
Change default locale to en-US everywhere, lower retry times

### DIFF
--- a/src/dialogs/__tests__/app-prefs.test.tsx
+++ b/src/dialogs/__tests__/app-prefs.test.tsx
@@ -56,9 +56,9 @@ describe('<AppPrefsDialog>', () => {
 	});
 
 	it('uses the closest app locale possible', () => {
-		renderComponent({locale: 'en-US'});
+		renderComponent({locale: 'fr-CA'});
 		expect(screen.getByLabelText('dialogs.appPrefs.language')).toHaveValue(
-			'en'
+			'fr'
 		);
 	});
 

--- a/src/util/__tests__/locales.test.ts
+++ b/src/util/__tests__/locales.test.ts
@@ -2,15 +2,15 @@ import {closestAppLocale} from '../locales';
 
 describe('closestAppLocale()', () => {
 	it('returns an exact match if one exists', () => {
-		expect(closestAppLocale('en')).toBe('en');
+		expect(closestAppLocale('fr')).toBe('fr');
 		expect(closestAppLocale('pt-br')).toBe('pt-br');
 	});
 
 	it('returns a rough match if one exists', () => {
-		expect(closestAppLocale('en-US')).toBe('en');
+		expect(closestAppLocale('fr-CA')).toBe('fr');
 		expect(closestAppLocale('da-DK')).toBe('da');
 	});
 
-	it("returns 'en' as a fallback", () =>
-		expect(closestAppLocale('martian')).toBe('en'));
+	it("returns 'en-us' as a fallback", () =>
+		expect(closestAppLocale('martian')).toBe('en-us'));
 });

--- a/src/util/i18n.ts
+++ b/src/util/i18n.ts
@@ -9,7 +9,10 @@ i18n
 	.use(initReactI18next)
 	.init({
 		debug: process.env.NODE_ENV === 'development',
-		backend: {loadPath: `${import.meta.env.BASE_URL}locales/{{lng}}.json`},
+		backend: {
+			loadPath: `${import.meta.env.BASE_URL}locales/{{lng}}.json`,
+			maxRetries: 1
+		},
 		fallbackLng: 'en-us',
 		interpolation: {
 			escapeValue: false

--- a/src/util/locales.ts
+++ b/src/util/locales.ts
@@ -7,7 +7,10 @@ export const locales = [
 	{code: 'cs', name: 'Čeština'},
 	{code: 'da', name: 'Dansk'},
 	{code: 'de', name: 'Deutsch'},
-	{code: 'en', name: 'English'},
+	// If and when we have a British/other localization, then we'll need multiple
+	// English entries; default to en-us now to speed up loads and avoid trying to
+	// load a nonexistent `en.json` file.
+	{code: 'en-us', name: 'English'},
 	{code: 'es', name: 'Castellano'},
 	{code: 'fi', name: 'Suomi'},
 	{code: 'fr', name: 'Français'},
@@ -48,5 +51,5 @@ export function closestAppLocale(code: string) {
 		}
 	}
 
-	return 'en';
+	return 'en-us';
 }


### PR DESCRIPTION
Loading just `en` was causing delays while trying to load a nonexistent file

Resolves #1670