### PR TITLE
Update pl.json 455 - 18.04.2026

### DIFF
--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -182,6 +182,11 @@
 			"language": "Język",
 			"passageEditorFont": "Czcionka edytora scen",
 			"passageEditorFontScale": "Rozmiar czcionki edytora scen",
+			"passageTagDisplay": "Wyświetl tagi edytora scen jako",
+			"passageTagDisplays": {
+				"color": "Kolor",
+				"name": "Nazwa"
+			},
 			"themeLight": "Jasny",
 			"themeDark": "Ciemny",
 			"themeSystem": "Systemowy",


### PR DESCRIPTION
Added missing lines for the Passage tag display.

# Description
Added missing lines for the pl.json translation, so the file will be up to date, the same as english.