### PR TITLE
Make dialog collapsed and maximized states mutually exclusive

### DIFF
--- a/src/dialogs/context/__tests__/reducer.test.ts
+++ b/src/dialogs/context/__tests__/reducer.test.ts
@@ -212,6 +212,30 @@ describe('Dialog reducer', () => {
 				}
 			]));
 
+		it('unmaximizes a dialog when collapsing it', () =>
+			expect(
+				reducer(
+					[
+						{
+							collapsed: false,
+							component: mockComponent,
+							highlighted: false,
+							maximized: true,
+							props: {mockProp: true}
+						}
+					],
+					{type: 'setDialogCollapsed', collapsed: true, index: 0}
+				)
+			).toEqual([
+				{
+					collapsed: true,
+					component: mockComponent,
+					highlighted: false,
+					maximized: false,
+					props: {mockProp: true}
+				}
+			]));
+
 		it('does nothing if an incorrect index is specified', () =>
 			expect(
 				reducer(
@@ -412,6 +436,30 @@ describe('Dialog reducer', () => {
 					highlighted: false,
 					maximized: false,
 					props: {mockProp: false}
+				}
+			]));
+
+		it('expands a dialog when maximizing it', () =>
+			expect(
+				reducer(
+					[
+						{
+							collapsed: true,
+							component: mockComponent,
+							highlighted: false,
+							maximized: false,
+							props: {mockProp: true}
+						}
+					],
+					{type: 'setDialogMaximized', maximized: true, index: 0}
+				)
+			).toEqual([
+				{
+					collapsed: false,
+					component: mockComponent,
+					highlighted: false,
+					maximized: true,
+					props: {mockProp: true}
 				}
 			]));
 

--- a/src/dialogs/context/__tests__/reducer.test.ts
+++ b/src/dialogs/context/__tests__/reducer.test.ts
@@ -236,6 +236,30 @@ describe('Dialog reducer', () => {
 				}
 			]));
 
+		it("doesn't change maximized state when setting collapsed to false", () =>
+			expect(
+				reducer(
+					[
+						{
+							collapsed: false,
+							component: mockComponent,
+							highlighted: false,
+							maximized: true,
+							props: {mockProp: true}
+						}
+					],
+					{type: 'setDialogCollapsed', collapsed: false, index: 0}
+				)
+			).toEqual([
+				{
+					collapsed: false,
+					component: mockComponent,
+					highlighted: false,
+					maximized: true,
+					props: {mockProp: true}
+				}
+			]));
+
 		it('does nothing if an incorrect index is specified', () =>
 			expect(
 				reducer(
@@ -459,6 +483,30 @@ describe('Dialog reducer', () => {
 					component: mockComponent,
 					highlighted: false,
 					maximized: true,
+					props: {mockProp: true}
+				}
+			]));
+
+		it("doesn't change collapsed state when setting maximized to false", () =>
+			expect(
+				reducer(
+					[
+						{
+							collapsed: true,
+							component: mockComponent,
+							highlighted: false,
+							maximized: false,
+							props: {mockProp: true}
+						}
+					],
+					{type: 'setDialogMaximized', maximized: false, index: 0}
+				)
+			).toEqual([
+				{
+					collapsed: true,
+					component: mockComponent,
+					highlighted: false,
+					maximized: false,
 					props: {mockProp: true}
 				}
 			]));

--- a/src/dialogs/context/reducer.ts
+++ b/src/dialogs/context/reducer.ts
@@ -52,7 +52,11 @@ export const reducer: React.Reducer<DialogsState, DialogsAction> = (
 		case 'setDialogCollapsed':
 			return state.map((dialog, index) =>
 				index === action.index
-					? {...dialog, collapsed: action.collapsed}
+					? {
+							...dialog,
+							collapsed: action.collapsed,
+							maximized: action.collapsed ? false : dialog.maximized
+					  }
 					: dialog
 			);
 
@@ -66,6 +70,10 @@ export const reducer: React.Reducer<DialogsState, DialogsAction> = (
 		case 'setDialogMaximized':
 			return state.map((dialog, index) => ({
 				...dialog,
+				collapsed:
+					index === action.index && action.maximized
+						? false
+						: dialog.collapsed,
 				maximized: index === action.index ? action.maximized : false
 			}));
 


### PR DESCRIPTION
# Description

Enforces the dialog state invariant discussed in #1418: a dialog should not be both collapsed and maximized at the same time.

The reducer now clears `maximized` when a dialog is collapsed, and clears `collapsed` when a dialog is maximized. This prevents the remaining blank fullscreen dialog state caused by a maximized wrapper around a collapsed dialog (open the stylesheet/JavaScript pane, maximize it, then collapse it).

Adds reducer coverage for both state transitions.

## Notes for reviewer

Two things noted but intentionally **not changed here** — this PR sells one thing: the `!(collapsed && maximized)` invariant.

- `passage-edit-stack.tsx`'s `collapsed && maximized` style branch becomes dead code once that state can't occur. Left as-is; normal collapsed styling is unaffected.
- `setDialogMaximized` already clears `maximized` on all dialogs for an out-of-range index (the existing incorrect-index test doesn't exercise this). Pre-existing; untouched.

# Issues Fixed

Addresses the remaining dialog state issue discussed in #1418.

_Using "Addresses" rather than "Fixes" pending a manual UI pass on the stylesheet/JavaScript panel, a single passage editor, and a passage stack with several passages._

# Credit

Please put an X in *one* of the squares below only.

- [ ] I would like to be credited in the application as: ______
- [x] I would not like my name to appear in the application credits.

# Presubmission Checklist

Put an X in the squares below to indicate you've done each step.

- [x] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there.
- [x] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)
- [x] I have read and agree to abide by this project's Code of Conduct.