### PR TITLE
Flush pending passage text changes on blur

### DIFF
--- a/src/components/control/code-area/__mocks__/code-area.tsx
+++ b/src/components/control/code-area/__mocks__/code-area.tsx
@@ -22,7 +22,12 @@ export const CodeArea: React.FC<CodeAreaProps> = props => {
 			data-use-code-mirror={props.useCodeMirror}
 		>
 			<label>
-				{props.label} <textarea onChange={handleOnChange} value={props.value} />
+				{props.label}
+				<textarea
+					onBlur={props.onBlur}
+					onChange={handleOnChange}
+					value={props.value}
+				/>
 			</label>
 		</div>
 	);

--- a/src/components/control/code-area/code-area.tsx
+++ b/src/components/control/code-area/code-area.tsx
@@ -20,7 +20,8 @@ import {initPrefixTriggerGlobally} from '../../../codemirror/prefix-trigger';
 
 initPrefixTriggerGlobally();
 
-export interface CodeAreaProps extends Omit<IControlledCodeMirror, 'onBeforeChange'> {
+export interface CodeAreaProps
+	extends Omit<IControlledCodeMirror, 'onBeforeChange' | 'onBlur'> {
 	fontFamily?: string;
 	fontScale?: number;
 	// ID is required because nesting the input inside the label causes screen
@@ -28,6 +29,7 @@ export interface CodeAreaProps extends Omit<IControlledCodeMirror, 'onBeforeChan
 	id: string;
 	label: string;
 	labelHidden?: boolean;
+	onBlur?: () => void;
 	onChangeEditor?: (value: CodeMirror.Editor) => void;
 	onChangeText: (value: string, data?: CodeMirror.EditorChange) => void;
 	useCodeMirror?: boolean;
@@ -40,6 +42,7 @@ export const CodeArea: React.FC<CodeAreaProps> = props => {
 		fontScale,
 		id,
 		label,
+		onBlur,
 		onChangeEditor,
 		onChangeText,
 		useCodeMirror,
@@ -93,12 +96,14 @@ export const CodeArea: React.FC<CodeAreaProps> = props => {
 			{useCodeMirror ? (
 				<CodeMirror
 					{...otherProps}
+					onBlur={onBlur}
 					onBeforeChange={handleCodeMirrorBeforeChange}
 				/>
 			) : (
 				<textarea
 					className="visible"
 					id={id}
+					onBlur={onBlur}
 					onChange={({target}) => onChangeText(target.value)}
 					placeholder={otherProps.options?.placeholder}
 					style={style}

--- a/src/dialogs/passage-edit/__tests__/passage-text.test.tsx
+++ b/src/dialogs/passage-edit/__tests__/passage-text.test.tsx
@@ -237,6 +237,30 @@ describe('<PassageText>', () => {
 		expect(onChange.mock.calls).toEqual([['mock-change2']]);
 	});
 
+	it.each([true, false])(
+		'flushes pending passage text changes on blur when useCodeMirror is %s',
+		useCodeMirror => {
+			const onChange = jest.fn();
+
+			renderComponent({onChange}, {prefs: {useCodeMirror}});
+
+			const editor = screen.getByLabelText(
+				'dialogs.passageEdit.passageTextEditorLabel'
+			);
+
+			fireEvent.change(editor, {target: {value: 'mock-blur-change'}});
+			expect(onChange).not.toHaveBeenCalled();
+
+			fireEvent.blur(editor);
+
+			expect(onChange).toHaveBeenCalledTimes(1);
+			expect(onChange).toHaveBeenCalledWith('mock-blur-change');
+
+			jest.advanceTimersByTime(1000);
+			expect(onChange).toHaveBeenCalledTimes(1);
+		}
+	);
+
 	it('uses CodeMirror in the code area if enabled in preferences', () => {
 		renderComponent({}, {prefs: {useCodeMirror: true}});
 		expect(screen.getByTestId('mock-code-area')!.dataset.useCodeMirror).toBe(

--- a/src/dialogs/passage-edit/passage-text.tsx
+++ b/src/dialogs/passage-edit/passage-text.tsx
@@ -43,6 +43,22 @@ export const PassageText: React.FC<PassageTextProps> = props => {
 	const onChangeText = React.useRef<string>();
 	const onChangeTimeout = React.useRef<number>();
 
+	const commitPendingChange = React.useCallback(() => {
+		onChangeTimeout.current = undefined;
+		onChange(onChangeText.current!);
+	}, [onChange]);
+
+	const scheduleCommit = React.useCallback(() => {
+		onChangeTimeout.current = window.setTimeout(commitPendingChange, 1000);
+	}, [commitPendingChange]);
+
+	const flushPendingChange = React.useCallback(() => {
+		if (onChangeTimeout.current) {
+			window.clearTimeout(onChangeTimeout.current);
+			commitPendingChange();
+		}
+	}, [commitPendingChange]);
+
 	// Effects to handle debouncing updates upward. The idea here is that the
 	// component maintains a local state so that the CodeMirror instance always is
 	// up-to-date with what the user has typed, but the global context may not be.
@@ -76,21 +92,9 @@ export const PassageText: React.FC<PassageTextProps> = props => {
 			// effect.
 
 			onChangeText.current = text;
-
-			// Queue a call to onChange.
-
-			onChangeTimeout.current = window.setTimeout(() => {
-				// Important to reset this ref so that we don't try to cancel fired
-				// timeouts above.
-
-				onChangeTimeout.current = undefined;
-
-				// Finally call the onChange prop.
-
-				onChange(onChangeText.current!);
-			}, 1000);
+			scheduleCommit();
 		},
-		[onChange, onEditorChange]
+		[onEditorChange, scheduleCommit]
 	);
 
 	// If the onChange prop changes while an onChange call is pending, reset the
@@ -99,14 +103,9 @@ export const PassageText: React.FC<PassageTextProps> = props => {
 	React.useEffect(() => {
 		if (onChangeTimeout.current) {
 			window.clearTimeout(onChangeTimeout.current);
-			onChangeTimeout.current = window.setTimeout(() => {
-				// This body must be the same as in the timeout in the previous effect.
-
-				onChangeTimeout.current = undefined;
-				onChange(onChangeText.current!);
-			}, 1000);
+			scheduleCommit();
 		}
-	}, [onChange]);
+	}, [scheduleCommit]);
 
 	const handleMount = React.useCallback(
 		(editor: CodeMirror.Editor) => {
@@ -171,6 +170,7 @@ export const PassageText: React.FC<PassageTextProps> = props => {
 				id={`passage-dialog-passage-text-code-area-${passage.id}`}
 				label={t('dialogs.passageEdit.passageTextEditorLabel')}
 				labelHidden
+				onBlur={flushPendingChange}
 				onChangeEditor={onEditorChange}
 				onChangeText={handleLocalChangeText}
 				options={options}


### PR DESCRIPTION
# Description

Adds a small blur-boundary flush in `PassageText`.

Passage text still uses the existing 1000 ms debounced `onChange` path while typing. If the editor is blurred while a pending text change exists, the pending timeout is cleared and the latest local text is sent through `onChange` immediately.

This is intended to address stale global story state when the user leaves the passage editor and immediately triggers build/export/test-style actions.

This keeps the scope limited to `PassageText` and does not add a central pending-editor flush, build/export action changes, or page/app exit handling.

Verification performed:

- `git diff --check` passes.
- `npx jest src/dialogs/passage-edit/__tests__/passage-text.test.tsx --runInBand --watch=false` passes.
- Manual/browser check: with Enhanced Editors ON, the passage body editor is visible/focusable/editable, and immediate Export as Twee includes the latest marker.
- Manual/browser check: with Enhanced Editors OFF, the passage body editor is visible/focusable/editable, and immediate Export as Twee includes the latest marker.

# Issues Fixed

Addresses #1689.

# Credit

Please put an X in *one* of the squares below only.

[ ] I would like to be credited in the application as: ______ \
[x] I would not like my name to appear in the application credits.

# Presubmission Checklist

Put an X in the squares below to indicate you've done each step.

[x] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[x] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[x] I have read and agree to abide by this project's Code of Conduct.