### PR TITLE
Fixed broken links in docs

### DIFF
--- a/docs/en/src/README.md
+++ b/docs/en/src/README.md
@@ -44,7 +44,7 @@ done with Twine--but you might be better-served using a different tool.
   [Inform](http://inform7.com) or [Bitsy](http://www.bitsy.org), for example,
   might be better fits for these.
 
-See [Limitations](../limitations/index.md) for more details on some of the above and some possible ways
+See [Limitations](../en/limitations/index.md) for more details on some of the above and some possible ways
 to work around these issues.
 
 ## See Also...

--- a/docs/en/src/README.md
+++ b/docs/en/src/README.md
@@ -44,7 +44,7 @@ done with Twine--but you might be better-served using a different tool.
   [Inform](http://inform7.com) or [Bitsy](http://www.bitsy.org), for example,
   might be better fits for these.
 
-See [Limitations](../en/limitations/index.md) for more details on some of the above and some possible ways
+See [Limitations](./limitations/index.md) for more details on some of the above and some possible ways
 to work around these issues.
 
 ## See Also...

--- a/docs/en/src/editing-stories/editing-passages.md
+++ b/docs/en/src/editing-stories/editing-passages.md
@@ -11,7 +11,7 @@ For instance, you might enter code into your passage to set variables or
 conditionally display some text.
 
 The font and size of the text can be customized in [Twine's
-preferences](../preferences). This doesn't change what the passage looks like
+preferences](../customizing/preferences.md). This doesn't change what the passage looks like
 when played; it just lets you make the text editor more comfortable to use.
 
 Story formats can extend Twine to add syntax formatting to the passage text

--- a/docs/en/src/editing-stories/navigating.md
+++ b/docs/en/src/editing-stories/navigating.md
@@ -38,13 +38,13 @@ list of matches.
 An empty passage is one you haven't written any text in (usually). These show up
 in the Story Map as translucent cards with a dotted border. Twine automatically
 creates and deletes empty passages when you [edit links in
-passages](./editing-passages.md).
+passages](editing-passages.md).
 
 ## Tags
 
 Passages will show [tags you've assigned to them](tagging.md) in two different
 ways, depending on what [the preference you've
-selected](../customizing/preferences.html):
+selected](../customizing/preferences.md):
 
 - If you choose to show tags as colors (which is the default setting), then
   passages with those tags will have a small stripe of that color at their top.
@@ -67,7 +67,7 @@ passage edit dialog.
 
 If there is a link in a passage that Twine can't find a passage for, it will
 instead show a red line ending in a 'no entry' symbol. [Edit the
-passage](editing.md) to correct the problem.
+passage](editing-passages.md) to correct the problem.
 
 ## References
 

--- a/docs/en/src/getting-started/getting-around.md
+++ b/docs/en/src/getting-started/getting-around.md
@@ -32,7 +32,7 @@ resides. This opens this guide in your web browser.
 No matter where you are in Twine, there will be a tab at the end of the top
 toolbar labeled _Twine_. This tab contains actions related to Twine itself.
 
-- _Preferences_ opens the [Preferences dialog](../preferences), where you can
+- _Preferences_ opens the [Preferences dialog](../customizing/preferences.md), where you can
   customize how Twine works.
 - _Story Formats_ takes you to the [Story Formats](../story-formats) screen,
   where you can manage story formats installed in your version of Twine.

--- a/docs/en/src/getting-started/getting-around.md
+++ b/docs/en/src/getting-started/getting-around.md
@@ -59,4 +59,4 @@ Dialog boxes have a few controls in their title bar:
 
 You can have as many dialogs open as you have room onscreen for. Right now, the
 order of dialogs can't be changed, nor can their position onscreen be changed.
-The width of dialogs can be changed in [preferences](../preferences).
+The width of dialogs can be changed in [preferences](../customizing/preferences.md).

--- a/docs/en/src/release-notes/2-1.md
+++ b/docs/en/src/release-notes/2-1.md
@@ -31,8 +31,8 @@ stories into this new folder.
 - You can now widen the passage, JavaScript, and stylesheet editor windows.
 - Revised syntax colors in the JavaScript and stylesheet editors to be more
   readable.
-- Includes SugarCube 2.16.0.
-- Includes Harlowe 1.2.4 and 2.0.1.
+- Includes SugarCube [2.16.0](https://www.motoslave.net/sugarcube/2/releases.php#v2.16.0).
+- Includes Harlowe 1.2.4 and [2.0.1](https://twine2.neocities.org/2#changes_2.0.1-changes).
 
 ## Bugfixes
 
@@ -62,7 +62,7 @@ Release Date: March 1, 2017
 ## Features added
 
 - Added Czech, German, Italian, and Portuguese localizations.
-- Updated SugarCube to version 2.14.0.
+- Updated SugarCube to version [2.14.0](https://www.motoslave.net/sugarcube/2/releases.php#v2.14.0).
 - Outdated story formats are now removed automatically.
 
 ## Bugfixes

--- a/docs/en/src/release-notes/2-10.md
+++ b/docs/en/src/release-notes/2-10.md
@@ -20,4 +20,4 @@ Release Date: November 24, 2024
 
 ## Story Format Updates
 
-- Chapbook has been updated to version [2.3.0](https://klembot.github.io/chapbook/guide/references/version-history.html#230-24-november-24).
+- Chapbook has been updated to version [2.3.0](https://klembot.github.io/chapbook/guide/en/references/version-history.html#230-24-november%C2%A02024).

--- a/docs/en/src/release-notes/2-2.md
+++ b/docs/en/src/release-notes/2-2.md
@@ -24,8 +24,8 @@ Release Date: December 14, 2017
 - A Turkish localization has been added thanks to H. Utku Maden.
 - A number of extraneous libraries have been removed, so the overall file size
   of the app has been decreased, and it should load faster.
-- The built-in SugarCube story format has been updated to 2.21.0.
-- The built-in Harlowe story format has been updated to 2.1.0.
+- The built-in SugarCube story format has been updated to [2.21.0](https://www.motoslave.net/sugarcube/2/releases.php#v2.21.0).
+- The built-in Harlowe story format has been updated to [2.1.0](https://twine2.neocities.org/2#changes_2.1.0-changes).
 
 ## Bugfixes
 

--- a/docs/en/src/release-notes/2-3.md
+++ b/docs/en/src/release-notes/2-3.md
@@ -6,7 +6,7 @@ This is a maintenance release for Twine 2.3.
 
 ## Features added
 
-Updated SugarCube to 2.36.1.
+Updated SugarCube to [2.36.1](https://www.motoslave.net/sugarcube/2/releases.php#v2.36.1).
 
 ---
 
@@ -46,7 +46,7 @@ This is a maintenance release for Twine 2.3.
 
 ## Features added
 
-- Includes a corrected version of Chapbook 1.2.1 that includes testing functionality.
+- Includes a corrected version of Chapbook [1.2.1](https://klembot.github.io/chapbook/guide/en/references/version-history.html#121-17-january%C2%A02021) that includes testing functionality.
 
 ---
 
@@ -58,7 +58,7 @@ This is a maintenance release for Twine 2.3.
 
 ## Features added
 
-- Updated SugarCube to version 2.34.1.
+- Updated SugarCube to version [2.34.1](https://www.motoslave.net/sugarcube/2/releases.php#v2.34.1).
 - Removed the "Reload" menu item in desktop app versions which could cause data loss.
 
 ---
@@ -72,20 +72,7 @@ This is a maintenance release for Twine 2.3.
 ## Features added
 
 - Updates Harlowe to version 3.2.1.
-- Updates Chapbook to version 1.2.1.
-
----
-
-# Twine 2.3.11
-
-Release Date: January 17, 2021
-
-This is a maintenance release for Twine 2.3.
-
-## Features added
-
-- Updates Harlowe to version 3.2.1.
-- Updates Chapbook to version 1.2.1.
+- Updates Chapbook to version [1.2.1](https://klembot.github.io/chapbook/guide/en/references/version-history.html#121-17-january%C2%A02021).
 
 ---
 
@@ -110,7 +97,7 @@ This is a maintenance release for Twine 2.3.
 ## Features added
 
 - Fixed a bug with story renaming in the app version.
-- Updated Chapbook to version 1.2.0.
+- Updated Chapbook to version [1.2.0](https://klembot.github.io/chapbook/guide/en/references/version-history.html#120-6-july%C2%A02020).
 - Fixed a bug with story color selection in the story list.
 
 ---
@@ -128,7 +115,7 @@ This is a maintenance release for Twine 2.3.
 - On iOS, Twine now prompts to be added to the home screen, which will prevent
   story data from being automatically [deleted after 7 days of
   inactivity](https://webkit.org/blog/10218/full-third-party-cookie-blocking-and-more/).
-- Updated Chapbook to the latest version, 1.1.0.
+- Updated Chapbook to the latest version, [1.1.0](https://klembot.github.io/chapbook/guide/en/references/version-history.html#110-10-may%C2%A02020).
 
 ---
 
@@ -140,7 +127,7 @@ This is a maintenance release for Twine 2.3.
 
 ## Features added
 
-- Updated version of SugarCube story format, 2.31.1.
+- Updated version of SugarCube story format, [2.31.1](https://www.motoslave.net/sugarcube/2/releases.php#v2.31.1).
 
 ---
 
@@ -165,7 +152,7 @@ This is a maintenance release for Twine 2.3.
 
 ## Features added
 
-- The built-in version of SugarCube has been upgraded to 2.30.0.
+- The built-in version of SugarCube has been upgraded to [2.30.0](https://www.motoslave.net/sugarcube/2/releases.php#v2.30.0).
 - Added Slovenian and Japanese localizations.
 
 ## Bugs fixed
@@ -185,10 +172,10 @@ This is a maintenance release for Twine 2.3.
 
 ## Features added
 
-- Added Chapbook 1.0.0, a new story format.
+- Added [Chapbook](https://klembot.github.io/chapbook/) 1.0.0, a new story format.
 - Upgraded Harlowe to 3.1.0.
 - Upgraded Snowman to 1.4.0 and 2.0.0 respectively.
-- Upgraded SugarCube to 2.29.0.
+- Upgraded SugarCube to [2.29.0](https://www.motoslave.net/sugarcube/2/releases.php#v2.29.0).
 - Added Ukrainian localization (thanks to uk123ua).
 
 ---
@@ -278,7 +265,7 @@ Release Date: April 14, 2019
   where possible.
 - Bahasa Malaysia and Russian have been added as locale choices.
 - Harlowe has been updated to 3.0.1.
-- SugarCube has been updated to 2.28.2.
+- SugarCube has been updated to [2.28.2](https://www.motoslave.net/sugarcube/2/releases.php#v2.28.2).
 
 ## Bugs fixed
 

--- a/docs/en/src/release-notes/2-4.md
+++ b/docs/en/src/release-notes/2-4.md
@@ -28,7 +28,7 @@ Backups work properly in app Twine.
 
 ## Story Formats
 
-Harlowe is updated to [3.3.1](https://twine2.neocities.org/#changes_3.3.1-changes-(july-13,-2022))
+Harlowe is updated to [3.3.1](https://twine2.neocities.org/#changes_3.3.1-changes-(july-13,-2022)).
 
 ## Known Issues
 

--- a/docs/en/src/release-notes/2-4.md
+++ b/docs/en/src/release-notes/2-4.md
@@ -28,7 +28,7 @@ Backups work properly in app Twine.
 
 ## Story Formats
 
-Harlowe is updated to 3.3.1. (changelog)
+Harlowe is updated to [3.3.1](https://twine2.neocities.org/#changes_3.3.1-changes-(july-13,-2022))
 
 ## Known Issues
 
@@ -105,6 +105,6 @@ and add additional connections between passages in the map.
 
 ## Story Formats
 
-Harlowe 3.3.0 is included, and release notes are here.
+Harlowe [3.3.0](https://twine2.neocities.org/#changes_3.3.0-changes-(july-5,-2022)) is included, and release notes are here.
 
-Chapbook 1.2.2 is also included. It's the same as the last version, 1.2.1, except for the addition of editor extensions.
+Chapbook [1.2.2](https://klembot.github.io/chapbook/guide/en/references/version-history.html#122-5-april%C2%A02022) is also included. It's the same as the last version, [1.2.1](https://klembot.github.io/chapbook/guide/en/references/version-history.html#121-17-january%C2%A02021), except for the addition of editor extensions.

--- a/docs/en/src/release-notes/2-5.md
+++ b/docs/en/src/release-notes/2-5.md
@@ -52,4 +52,4 @@ Release Date: August 27, 2022
 
 ## Story Format Updates
 
-Harlowe has been updated to 3.3.2.
+Harlowe has been updated to [3.3.2](https://twine2.neocities.org/#changes_3.3.2-changes-(aug-28,-2022)).

--- a/docs/en/src/release-notes/2-6.md
+++ b/docs/en/src/release-notes/2-6.md
@@ -8,8 +8,8 @@ Release Date: February 26, 2023
 
 ## Story Format Updates
 
-- Chapbook has been updated to version 1.2.3.
-- Harlowe has been updated to version 3.3.5.
+- Chapbook has been updated to version [1.2.3](https://klembot.github.io/chapbook/guide/en/references/version-history.html#123-26-february%C2%A02023).
+- Harlowe has been updated to version [3.3.5](https://twine2.neocities.org/#changes_3.3.5-changes-(feb-27,-2023)).
 
 ---
 
@@ -80,4 +80,4 @@ Support for 64-bit Linux should not change.
 
 ## Story Format Updates
 
-Harlowe has been updated to version 3.3.4.
+Harlowe has been updated to version [3.3.4](https://twine2.neocities.org/#changes_3.3.4-changes-(jan-09,-2023)).

--- a/docs/en/src/release-notes/2-7.md
+++ b/docs/en/src/release-notes/2-7.md
@@ -9,7 +9,7 @@ Release Date: August 27, 2023
 ## Story Format Updates
 
 - Harlowe has been updated to [version
-  3.3.7](https://twine2.neocities.org/#section_changes).
+  3.3.7](https://twine2.neocities.org/#changes_3.3.7-changes-(aug-27,-2023)).
 
 ---
 
@@ -35,4 +35,4 @@ Release Date: July 8, 2023
 ## Story Format Updates
 
 - Harlowe has been updated to [version
-  3.3.6](https://twine2.neocities.org/#section_changes).
+  3.3.6](https://twine2.neocities.org/#changes_3.3.6-changes-(jul-07,-2023)).

--- a/docs/en/src/release-notes/2-8.md
+++ b/docs/en/src/release-notes/2-8.md
@@ -12,7 +12,7 @@ Release Date: January 3, 2024
 ## Story Format Updates
 
 - Harlowe has been updated to [version
-  3.3.8](https://twine2.neocities.org/#section_changes).
+  3.3.8](https://twine2.neocities.org/#changes_3.3.8-changes-(jan-03,-2024)).
 
 ## Documentation
 

--- a/docs/en/src/release-notes/2-9.md
+++ b/docs/en/src/release-notes/2-9.md
@@ -12,8 +12,8 @@ Release Date: July 28, 2024
 
 ## Story Format Updates
 
-- Chapbook has been updated to version [2.2.0](https://klembot.github.io/chapbook/guide/references/version-history.html#220-28-july-2024).
-- SugarCube has been updated to version [2.37.3](http://www.motoslave.net/sugarcube/2/releases.php).
+- Chapbook has been updated to version [2.2.0](https://klembot.github.io/chapbook/guide/en/references/version-history.html#220-28-july%C2%A02024).
+- SugarCube has been updated to version [2.37.3](https://www.motoslave.net/sugarcube/2/releases.php#v2.37.3).
 
 ## 2.9.1
 
@@ -31,7 +31,7 @@ Release Date: July 21, 2024
 
 ## Story Format Updates
 
-- SugarCube has been updated to version [2.37.0](http://www.motoslave.net/sugarcube/2/releases.php).
+- SugarCube has been updated to version [2.37.0](https://www.motoslave.net/sugarcube/2/releases.php#v2.37.0).
 
 ## 2.9.0
 
@@ -55,6 +55,6 @@ Release Date: June 16, 2024
 ## Story Format Updates
 
 - Chapbook has been updated to version
-  [2.1.0](https://klembot.github.io/chapbook/guide/references/version-history.html#210-16-june-2024).
+  [2.1.0](https://klembot.github.io/chapbook/guide/en/references/version-history.html#210-16-june%C2%A02024).
 - Harlowe has been updated to version
-  [3.3.9](<https://twine2.neocities.org/#changes_3.3.8-changes-(jan-03,-2024)>).
+  [3.3.9](https://twine2.neocities.org/#changes_3.3.9-changes-(jun-16,-2024)).

--- a/docs/en/src/troubleshooting/backups.md
+++ b/docs/en/src/troubleshooting/backups.md
@@ -25,6 +25,6 @@ You must keep backups yourself using the
 You may not be completely out of luck.
 
 In addition to automatic backups, app Twine creates files in the [scratch
-folder](../publishing/scratch.md). Files in this folder are created when you
+folder](../publishing/scratch-folder.md). Files in this folder are created when you
 play, test, or proof a story. You may be able to recover your work from files
 here.


### PR DESCRIPTION
# Description

Fixed broken links in docs and removed redundant change log. 

# Issues Fixed
- Fixed internal documentation links wherever possible. 
- Fixed links to change logs of story formats. 
    - The English version of the change log for Chapbook was moved from `https://klembot.github.io/chapbook/guide/references/version-history.html` to `https://klembot.github.io/chapbook/guide/en/references/version-history.html`.
    - Appropriate page jumps have been added wherever possible. 
- Removed a duplicate change log entry for 2.3.11.

# Credit

Please put an X in *one* of the squares below only.

[X] I would like to be credited in the application as: Sriram
[ ] I would not like my name to appear in the application credits.

# Presubmission Checklist

Put an X in the squares below to indicate you've done each step.

[X] I have read this project's CONTRIBUTING file and this PR follows the criteria laid out there. \
[X] This contribution was created by me and I have the right to submit it under the GPL v3 license. (This is not a rights assignment.)\
[X] I have read and agree to abide by this project's Code of Conduct.